### PR TITLE
[FLINK-38544] Spilling v2 POC phases 1-5

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/BufferRequester.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/BufferRequester.java
@@ -33,10 +33,9 @@ public interface BufferRequester {
 
     /**
      * Blocks until a buffer is available from the source channel's pool. Implementations are
-     * expected to delegate to {@code RecoveredInputChannel.requestBufferBlocking()} (the existing
-     * method on master, with the heap fallback removed in Phase 4). Internally parks on the
-     * per-channel {@code BufferManager.bufferQueue} ({@code Object.wait / notifyAll}), woken by the
-     * {@code BufferPool}'s {@code BufferListener} callback.
+     * expected to delegate to {@code RecoveredInputChannel.requestBufferBlocking()}, which parks on
+     * the per-channel {@code BufferManager.bufferQueue} ({@code Object.wait / notifyAll}) and is
+     * woken by the {@code BufferPool}'s {@code BufferListener} callback.
      *
      * <p>Caller MUST NOT hold {@code SpillFileReader.lock}. Parking inside the lock would stall the
      * checkpoint trigger whenever buffer-pool pressure causes a wait, because the task thread

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/BufferRequester.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/BufferRequester.java
@@ -23,10 +23,10 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import java.io.IOException;
 
 /**
- * Funnels every buffer allocation that the drain (SpillFileReader) needs. Lives in the same
- * package as {@code SpillFileReader}, so {@code SpillFileReader} depends only on this interface;
- * the cross-package access to {@code RecoveredInputChannel}'s release primitive is encapsulated
- * inside the single implementation {@code RecoveredChannelBufferRequester}.
+ * Funnels every buffer allocation that the drain (SpillFileReader) needs. Lives in the same package
+ * as {@code SpillFileReader}, so {@code SpillFileReader} depends only on this interface; the
+ * cross-package access to {@code RecoveredInputChannel}'s release primitive is encapsulated inside
+ * the single implementation {@code RecoveredChannelBufferRequester}.
  */
 @Internal
 public interface BufferRequester {
@@ -35,11 +35,11 @@ public interface BufferRequester {
      * Blocks until a buffer is available from the source channel's pool. Implementations are
      * expected to delegate to {@code RecoveredInputChannel.requestBufferBlocking()} (the existing
      * method on master, with the heap fallback removed in Phase 4). Internally parks on the
-     * per-channel {@code BufferManager.bufferQueue} ({@code Object.wait / notifyAll}), woken by
-     * the {@code BufferPool}'s {@code BufferListener} callback.
+     * per-channel {@code BufferManager.bufferQueue} ({@code Object.wait / notifyAll}), woken by the
+     * {@code BufferPool}'s {@code BufferListener} callback.
      *
-     * <p>Caller MUST NOT hold {@code SpillFileReader.lock}. Parking inside the lock would stall
-     * the checkpoint trigger whenever buffer-pool pressure causes a wait, because the task thread
+     * <p>Caller MUST NOT hold {@code SpillFileReader.lock}. Parking inside the lock would stall the
+     * checkpoint trigger whenever buffer-pool pressure causes a wait, because the task thread
      * cannot acquire the lock to insert its barrier.
      *
      * @param channelInfo identifies the channel whose buffer pool to allocate from

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/BufferRequester.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/BufferRequester.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import java.io.IOException;
+
+/**
+ * Funnels every buffer allocation that the drain (SpillFileReader) needs. Lives in the same
+ * package as {@code SpillFileReader}, so {@code SpillFileReader} depends only on this interface;
+ * the cross-package access to {@code RecoveredInputChannel}'s release primitive is encapsulated
+ * inside the single implementation {@code RecoveredChannelBufferRequester}.
+ */
+@Internal
+public interface BufferRequester {
+
+    /**
+     * Blocks until a buffer is available from the source channel's pool. Implementations are
+     * expected to delegate to {@code RecoveredInputChannel.requestBufferBlocking()} (the existing
+     * method on master, with the heap fallback removed in Phase 4). Internally parks on the
+     * per-channel {@code BufferManager.bufferQueue} ({@code Object.wait / notifyAll}), woken by
+     * the {@code BufferPool}'s {@code BufferListener} callback.
+     *
+     * <p>Caller MUST NOT hold {@code SpillFileReader.lock}. Parking inside the lock would stall
+     * the checkpoint trigger whenever buffer-pool pressure causes a wait, because the task thread
+     * cannot acquire the lock to insert its barrier.
+     *
+     * @param channelInfo identifies the channel whose buffer pool to allocate from
+     * @return a pooled buffer ready for writing recovered data
+     * @throws InterruptedException if the thread is interrupted while waiting for a buffer
+     * @throws IOException if an I/O error occurs while requesting the buffer
+     */
+    Buffer requestBufferBlocking(InputChannelInfo channelInfo)
+            throws InterruptedException, IOException;
+
+    /**
+     * Called once at end of drain. Releases the exclusive buffers held by every source channel
+     * served by this requester. Implementations are expected to iterate the source channels and
+     * call {@code RecoveredInputChannel.releaseAllResources()} on each.
+     *
+     * <p>Single-threaded — no lock required. Drain has finished and no concurrent producer is
+     * active at this point.
+     *
+     * @throws IOException if releasing any channel's resources fails
+     */
+    void releaseExclusiveBuffers() throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequest.java
@@ -17,9 +17,12 @@
 
 package org.apache.flink.runtime.checkpoint.channel;
 
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter.ChannelStateWriteResult;
 import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.util.CloseableIterator;
@@ -258,6 +261,20 @@ abstract class ChannelStateWriteRequest {
         return new CheckpointAbortRequest(jobVertexID, subtaskIndex, checkpointId, cause);
     }
 
+    /**
+     * Factory for the spill-replay request that feeds Step 3 of the recovery-checkpoint protocol.
+     * The returned request iterates {@code chunks} on the writer thread, adapts each raw byte
+     * payload into a one-shot unpooled {@link Buffer}, and demuxes the payload into the
+     * cpId-bucketed input channel stream by {@code chunk.channelInfo}.
+     */
+    static ChannelStateWriteRequest replayInputDataFromSpill(
+            JobVertexID jobVertexID,
+            int subtaskIndex,
+            long checkpointId,
+            CloseableIterator<DiskSnapshot.Chunk> chunks) {
+        return new SpillInputReplayRequest(jobVertexID, subtaskIndex, checkpointId, chunks);
+    }
+
     static ChannelStateWriteRequest registerSubtask(JobVertexID jobVertexID, int subtaskIndex) {
         return new SubtaskRegisterRequest(jobVertexID, subtaskIndex);
     }
@@ -421,4 +438,61 @@ final class SubtaskReleaseRequest extends ChannelStateWriteRequest {
 
     @Override
     public void cancel(Throwable cause) throws Exception {}
+}
+
+/**
+ * Writer-thread request that replays spill-file entries captured by a recovery-time {@link
+ * DiskSnapshot} into the cpId-bucketed input channel stream. The dispatcher routes this request to
+ * {@link ChannelStateCheckpointWriter#writeInput} demuxed by {@code chunk.channelInfo}. The raw
+ * payload bytes are wrapped in a per-iteration unpooled {@link NetworkBuffer} so the buffer pool is
+ * never touched on the writer side.
+ */
+final class SpillInputReplayRequest extends ChannelStateWriteRequest {
+
+    private final CloseableIterator<DiskSnapshot.Chunk> chunks;
+
+    SpillInputReplayRequest(
+            JobVertexID jobVertexID,
+            int subtaskIndex,
+            long checkpointId,
+            CloseableIterator<DiskSnapshot.Chunk> chunks) {
+        super(jobVertexID, subtaskIndex, checkpointId, "replayInputDataFromSpill");
+        this.chunks = Preconditions.checkNotNull(chunks);
+    }
+
+    /**
+     * Executes the demux on the writer thread. Each chunk is converted to a temporary {@link
+     * NetworkBuffer} backed by a wrap of the chunk's byte array — {@link FreeingBufferRecycler}
+     * means recycle simply discards the wrapper, leaving the byte array to normal GC. The chunks
+     * iterator is always closed (success and failure path).
+     */
+    void replay(ChannelStateCheckpointWriter writer) throws Exception {
+        try {
+            while (chunks.hasNext()) {
+                DiskSnapshot.Chunk chunk = chunks.next();
+                Buffer buffer =
+                        new NetworkBuffer(
+                                MemorySegmentFactory.wrap(chunk.data),
+                                FreeingBufferRecycler.INSTANCE,
+                                Buffer.DataType.DATA_BUFFER,
+                                chunk.length);
+                writer.writeInput(getJobVertexID(), getSubtaskIndex(), chunk.channelInfo, buffer);
+            }
+        } finally {
+            chunks.close();
+        }
+    }
+
+    @Override
+    public void cancel(Throwable cause) throws Exception {
+        try {
+            chunks.close();
+        } catch (Exception suppressed) {
+            if (cause != null) {
+                cause.addSuppressed(suppressed);
+            } else {
+                throw suppressed;
+            }
+        }
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImpl.java
@@ -123,11 +123,27 @@ final class ChannelStateWriteRequestDispatcherImpl implements ChannelStateWriteR
             handleCheckpointStartRequest(request);
         } else if (request instanceof CheckpointInProgressRequest) {
             handleCheckpointInProgressRequest((CheckpointInProgressRequest) request);
+        } else if (request instanceof SpillInputReplayRequest) {
+            handleSpillInputReplayRequest((SpillInputReplayRequest) request);
         } else if (request instanceof CheckpointAbortRequest) {
             handleCheckpointAbortRequest(request);
         } else {
             throw new IllegalArgumentException("unknown request type: " + request);
         }
+    }
+
+    /**
+     * Routes a recovery-time spill replay to the same {@link ChannelStateCheckpointWriter} that
+     * services live {@link CheckpointInProgressRequest}s for the same cpId. The dispatcher's {@code
+     * dispatch} wrapper invokes {@link SpillInputReplayRequest#cancel} on any thrown exception,
+     * which closes the chunks iterator and ultimately fires the snapshot-release callback the
+     * dispatcher attached at Step 3.
+     */
+    private void handleSpillInputReplayRequest(SpillInputReplayRequest req) throws Exception {
+        checkArgument(
+                ongoingCheckpointId == req.getCheckpointId() && writer != null,
+                "writer not found while processing request: " + req);
+        req.replay(writer);
     }
 
     private void handleAbortedRequest(ChannelStateWriteRequest request) throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
@@ -190,6 +190,26 @@ public interface ChannelStateWriter extends Closeable {
     ChannelStateWriteResult getAndRemoveWriteResult(long checkpointId)
             throws IllegalArgumentException;
 
+    /**
+     * Records input-channel state from a spill file that was written during the filter phase of a
+     * recovery-with-checkpoint. The writer asynchronously demuxes entries by {@code
+     * entry.channelInfo} into each channel's checkpoint output.
+     *
+     * <p>The default no-op closes {@code chunks} and swallows any exception on close; this covers
+     * all existing implementations that do not participate in the disk-spill path.
+     *
+     * @param checkpointId the checkpoint id that triggered the spill snapshot
+     * @param chunks iterator over spill-file entries; caller transfers ownership and the callee is
+     *     responsible for closing it
+     */
+    default void addInputDataFromSpill(
+            long checkpointId, CloseableIterator<DiskSnapshot.Chunk> chunks) {
+        try {
+            chunks.close();
+        } catch (Exception ignored) {
+        }
+    }
+
     ChannelStateWriter NO_OP = new NoOpChannelStateWriter();
 
     /** No-op implementation of {@link ChannelStateWriter}. */
@@ -229,6 +249,15 @@ public interface ChannelStateWriter extends Closeable {
             return new ChannelStateWriteResult(
                     CompletableFuture.completedFuture(Collections.emptyList()),
                     CompletableFuture.completedFuture(Collections.emptyList()));
+        }
+
+        @Override
+        public void addInputDataFromSpill(
+                long checkpointId, CloseableIterator<DiskSnapshot.Chunk> chunks) {
+            try {
+                chunks.close();
+            } catch (Exception ignored) {
+            }
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
@@ -191,6 +191,20 @@ public interface ChannelStateWriter extends Closeable {
             throws IllegalArgumentException;
 
     /**
+     * Looks up the in-flight {@link ChannelStateWriteResult} for {@code checkpointId} without
+     * removing it from the writer's internal map. Used by the recovery-checkpoint dispatcher to
+     * attach a snapshot-release callback that fires when the cpId's input-channel-state future
+     * completes (success or abort), without interfering with the subtask coordinator's later {@link
+     * #getAndRemoveWriteResult} consumption.
+     *
+     * <p>Default returns {@link ChannelStateWriteResult#EMPTY} so feature-off / no-op writers see a
+     * completed future and trigger the snapshot-release callback immediately.
+     */
+    default ChannelStateWriteResult peekWriteResult(long checkpointId) {
+        return ChannelStateWriteResult.EMPTY;
+    }
+
+    /**
      * Records input-channel state from a spill file that was written during the filter phase of a
      * recovery-with-checkpoint. The writer asynchronously demuxes entries by {@code
      * entry.channelInfo} into each channel's checkpoint output.
@@ -249,6 +263,11 @@ public interface ChannelStateWriter extends Closeable {
             return new ChannelStateWriteResult(
                     CompletableFuture.completedFuture(Collections.emptyList()),
                     CompletableFuture.completedFuture(Collections.emptyList()));
+        }
+
+        @Override
+        public ChannelStateWriteResult peekWriteResult(long checkpointId) {
+            return ChannelStateWriteResult.EMPTY;
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImpl.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.flink.runtime.checkpoint.channel.ChannelStateWriteRequest.completeInput;
 import static org.apache.flink.runtime.checkpoint.channel.ChannelStateWriteRequest.completeOutput;
+import static org.apache.flink.runtime.checkpoint.channel.ChannelStateWriteRequest.replayInputDataFromSpill;
 import static org.apache.flink.runtime.checkpoint.channel.ChannelStateWriteRequest.write;
 
 /**
@@ -236,6 +237,42 @@ public class ChannelStateWriterImpl implements ChannelStateWriter {
     }
 
     @Override
+    public void addInputDataFromSpill(
+            long checkpointId, CloseableIterator<DiskSnapshot.Chunk> chunks) {
+        // Empty snapshot: no IO and no writer-thread submission. Closing the iterator releases
+        // the SpillFile ref-count grant via DiskSnapshot.close (or is a no-op for the empty
+        // singleton).
+        if (!chunks.hasNext()) {
+            try {
+                chunks.close();
+            } catch (Exception e) {
+                LOG.warn(
+                        "{} failed to close empty DiskSnapshot for checkpoint {}",
+                        taskName,
+                        checkpointId,
+                        e);
+            }
+            return;
+        }
+        LOG.trace("{} replaying input data from spill, checkpoint {}", taskName, checkpointId);
+        try {
+            enqueue(
+                    replayInputDataFromSpill(jobVertexID, subtaskIndex, checkpointId, chunks),
+                    false);
+        } catch (RuntimeException e) {
+            // enqueue's failure path already invoked request.cancel which closes the iterator
+            // (releasing the SpillFile ref-count grant). Fail the write result so the dispatcher-
+            // attached snapshot-release callback fires for any concurrent waiter as well; the
+            // double-close on DiskSnapshot is safe — it is idempotent.
+            ChannelStateWriteResult result = results.get(checkpointId);
+            if (result != null) {
+                result.fail(e);
+            }
+            throw e;
+        }
+    }
+
+    @Override
     public void abort(long checkpointId, Throwable cause, boolean cleanup) {
         LOG.debug("{} aborting, checkpoint {}", taskName, checkpointId);
         enqueue(
@@ -257,6 +294,17 @@ public class ChannelStateWriterImpl implements ChannelStateWriter {
                 result != null,
                 taskName + " channel state write result not found for checkpoint " + checkpointId);
         return result;
+    }
+
+    /**
+     * {@inheritDoc} — returns the live result without removing it; falls back to {@link
+     * ChannelStateWriteResult#EMPTY} so the dispatcher's snapshot-release callback fires
+     * immediately when the cpId is unknown (no UC for this checkpoint).
+     */
+    @Override
+    public ChannelStateWriteResult peekWriteResult(long checkpointId) {
+        ChannelStateWriteResult result = results.get(checkpointId);
+        return result != null ? result : ChannelStateWriteResult.EMPTY;
     }
 
     // just for test

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/DiskSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/DiskSnapshot.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * A snapshot of the spill-file state at the moment a recovery checkpoint was triggered. Returned by
  * {@link RecoveryCheckpointTrigger#snapshotAndInsertBarriers} at Step 1 and fed into the
@@ -89,25 +91,40 @@ public final class DiskSnapshot implements CloseableIterator<DiskSnapshot.Chunk>
     private final SpillFile.Snapshot snapshot;
     private final StartPos startPos;
     private final List<SpillFile.Entry> entries;
+
+    /**
+     * Back-reference to the {@link SpillFile} that produced this snapshot, so {@link #close()} can
+     * release the ref-count grant taken at construction time. {@code null} only for the {@link
+     * #empty()} singleton, whose {@link #close()} is a no-op.
+     */
+    @javax.annotation.Nullable private final SpillFile spillFile;
+
     private int entryCursor;
     private boolean closed;
 
     /**
      * Constructs an empty snapshot — the {@link #empty()} singleton state. Iteration is immediately
-     * exhausted.
+     * exhausted and {@link #close()} is a no-op (no ref-count to release).
      */
     private DiskSnapshot() {
         this.snapshot = null;
         this.startPos = null;
         this.entries = java.util.Collections.emptyList();
+        this.spillFile = null;
         this.entryCursor = 0;
         this.closed = false;
     }
 
-    public DiskSnapshot(SpillFile.Snapshot snapshot, StartPos startPos) {
+    /**
+     * Constructs a non-empty snapshot. The caller must have already incremented {@code
+     * spillFile.acquire()} inside {@code SpillFileReader.lock} so the ref-count grant is paired
+     * with this instance's {@link #close()}.
+     */
+    public DiskSnapshot(SpillFile.Snapshot snapshot, StartPos startPos, SpillFile spillFile) {
         this.snapshot = snapshot;
         this.startPos = startPos;
         this.entries = snapshot.getEntries();
+        this.spillFile = checkNotNull(spillFile);
         this.entryCursor = 0;
         this.closed = false;
     }
@@ -142,13 +159,20 @@ public final class DiskSnapshot implements CloseableIterator<DiskSnapshot.Chunk>
     }
 
     /**
-     * Phase 4 release is a structural no-op; Phase 5 attaches a per-reader ref-counter so the
-     * spill-file segments can be deleted once both the drain and every in-recovery checkpoint
-     * reader have released their references.
+     * Releases this snapshot's ref-count grant on the underlying {@link SpillFile}. Idempotent —
+     * the first close decrements; subsequent closes are no-ops. The actual segment deletion is
+     * gated by {@code SpillFile.cleanedUp}, so the file is removed only after every reader plus the
+     * drain has released its grant.
      */
     @Override
-    public void close() {
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
         closed = true;
+        if (spillFile != null) {
+            spillFile.release();
+        }
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/DiskSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/DiskSnapshot.java
@@ -20,34 +20,32 @@ package org.apache.flink.runtime.checkpoint.channel;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.CloseableIterator;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
- * A snapshot of the spill-file state at the moment a recovery checkpoint was triggered. Returned
- * by {@link RecoveryCheckpointTrigger#snapshotAndInsertBarriers} at Step 1 and fed into
- * {@link ChannelStateWriter#addInputDataFromSpill} at Step 3.
+ * A snapshot of the spill-file state at the moment a recovery checkpoint was triggered. Returned by
+ * {@link RecoveryCheckpointTrigger#snapshotAndInsertBarriers} at Step 1 and fed into the
+ * channel-state writer at Step 3.
  *
- * <p>Iterating over a {@code DiskSnapshot} yields {@link Chunk} entries — one per spill-file
- * entry that falls within the snapshot window. The iteration starting point is captured as
- * {@link StartPos} inside the lock in {@code RecoveryCheckpointTrigger}, ensuring that entries
- * already delivered to channel queues before the checkpoint barrier are excluded from the disk
- * portion.
- *
- * <p>The real iteration logic (seeking to {@link StartPos} and reading entries) is introduced in
- * Phase 4. This skeleton provides the type declarations and the {@link #empty()} factory used by
- * the feature-off code path.
+ * <p>Iteration yields one {@link Chunk} per entry that falls strictly after {@link StartPos} —
+ * entries already delivered by the drain are skipped. {@link StartPos} is captured inside {@code
+ * SpillFileReader.lock} at the same instant the {@link RecoveryCheckpointBarrier} sentinels are
+ * inserted into channel queues; this guarantees the in-memory and on-disk portions are disjoint and
+ * cover every entry exactly once.
  */
 @Internal
 public final class DiskSnapshot implements CloseableIterator<DiskSnapshot.Chunk> {
 
-    /**
-     * A single recovered-state entry read from the spill file, belonging to one input channel.
-     */
+    /** A single recovered-state entry read from the spill file, belonging to one input channel. */
     public static final class Chunk {
         /** The channel this entry belongs to. */
         public final InputChannelInfo channelInfo;
+
         /** Raw bytes of the recovered buffer. */
         public final byte[] data;
+
         /** Number of valid bytes in {@link #data}. */
         public final int length;
 
@@ -60,16 +58,13 @@ public final class DiskSnapshot implements CloseableIterator<DiskSnapshot.Chunk>
 
     /**
      * The position within the spill file at which this snapshot begins. Captured atomically inside
-     * {@code SpillFileReader.lock} at the same instant that the {@link RecoveryCheckpointBarrier}
-     * sentinels are inserted into the channel queues. This guarantees that the disk and memory
-     * portions of the snapshot are disjoint and together cover all entries exactly once.
-     *
-     * <p>Phase 4 fills in the real seek logic; this skeleton declares the type so that the
-     * interface contract can be established without churn.
+     * {@code SpillFileReader.lock} together with the per-channel barrier inserts so the disk
+     * portion and the in-memory portion of the snapshot share a single physical instant.
      */
     public static final class StartPos {
         /** Index of the spill-file segment that is current at snapshot time. */
         public final int segmentIndex;
+
         /** Byte offset within that segment at snapshot time. */
         public final long offset;
 
@@ -82,33 +77,99 @@ public final class DiskSnapshot implements CloseableIterator<DiskSnapshot.Chunk>
     private static final DiskSnapshot EMPTY_INSTANCE = new DiskSnapshot();
 
     /**
-     * Returns a {@code DiskSnapshot} over an empty range: {@link #hasNext()} is always
-     * {@code false}, {@link #next()} always throws {@link NoSuchElementException}, and
-     * {@link #close()} is a no-op. Used by the feature-off code path where no spill file exists.
-     *
-     * @return the shared empty instance
+     * Returns a {@code DiskSnapshot} over an empty range: {@link #hasNext()} is always {@code
+     * false}, {@link #next()} always throws {@link NoSuchElementException}, and {@link #close()} is
+     * a no-op. Used by the feature-off code path where no spill file exists and by the
+     * recovery-already-done path where the drain has consumed all entries.
      */
     public static DiskSnapshot empty() {
         return EMPTY_INSTANCE;
     }
 
+    private final SpillFile.Snapshot snapshot;
+    private final StartPos startPos;
+    private final List<SpillFile.Entry> entries;
+    private int entryCursor;
+    private boolean closed;
+
     /**
-     * Default constructor. At this skeleton phase the instance is always in the empty state;
-     * Phase 4 will introduce the constructor that accepts a {@link StartPos} and the spill-file
-     * handle.
+     * Constructs an empty snapshot — the {@link #empty()} singleton state. Iteration is immediately
+     * exhausted.
      */
-    DiskSnapshot() {}
+    private DiskSnapshot() {
+        this.snapshot = null;
+        this.startPos = null;
+        this.entries = java.util.Collections.emptyList();
+        this.entryCursor = 0;
+        this.closed = false;
+    }
+
+    public DiskSnapshot(SpillFile.Snapshot snapshot, StartPos startPos) {
+        this.snapshot = snapshot;
+        this.startPos = startPos;
+        this.entries = snapshot.getEntries();
+        this.entryCursor = 0;
+        this.closed = false;
+    }
 
     @Override
     public boolean hasNext() {
-        return false;
+        if (closed) {
+            return false;
+        }
+        skipPreDrained();
+        return entryCursor < entries.size();
     }
 
     @Override
     public Chunk next() {
-        throw new NoSuchElementException("DiskSnapshot is empty");
+        if (closed) {
+            throw new NoSuchElementException("DiskSnapshot is closed");
+        }
+        skipPreDrained();
+        if (entryCursor >= entries.size()) {
+            throw new NoSuchElementException("DiskSnapshot is exhausted");
+        }
+        SpillFile.Entry e = entries.get(entryCursor++);
+        byte[] data = new byte[e.length];
+        try {
+            snapshot.getSegments().get(e.segmentIndex).readBytesAt(e.offset, e.length, data);
+        } catch (IOException ioe) {
+            throw new RuntimeException(
+                    "Failed to read spill entry from segment " + e.segmentIndex, ioe);
+        }
+        return new Chunk(e.channelInfo, data, e.length);
     }
 
+    /**
+     * Phase 4 release is a structural no-op; Phase 5 attaches a per-reader ref-counter so the
+     * spill-file segments can be deleted once both the drain and every in-recovery checkpoint
+     * reader have released their references.
+     */
     @Override
-    public void close() {}
+    public void close() {
+        closed = true;
+    }
+
+    /**
+     * Skips entries whose {@code (segmentIndex, offset)} is strictly before {@link #startPos}.
+     * Those have already been delivered by the drain and live in the channel queues — the caller
+     * observes them via the per-channel pre-barrier walk in Step 2.
+     */
+    private void skipPreDrained() {
+        if (startPos == null) {
+            return;
+        }
+        while (entryCursor < entries.size()) {
+            SpillFile.Entry e = entries.get(entryCursor);
+            boolean preDrained =
+                    e.segmentIndex < startPos.segmentIndex
+                            || (e.segmentIndex == startPos.segmentIndex
+                                    && e.offset < startPos.offset);
+            if (!preDrained) {
+                break;
+            }
+            entryCursor++;
+        }
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/DiskSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/DiskSnapshot.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.CloseableIterator;
+
+import java.util.NoSuchElementException;
+
+/**
+ * A snapshot of the spill-file state at the moment a recovery checkpoint was triggered. Returned
+ * by {@link RecoveryCheckpointTrigger#snapshotAndInsertBarriers} at Step 1 and fed into
+ * {@link ChannelStateWriter#addInputDataFromSpill} at Step 3.
+ *
+ * <p>Iterating over a {@code DiskSnapshot} yields {@link Chunk} entries — one per spill-file
+ * entry that falls within the snapshot window. The iteration starting point is captured as
+ * {@link StartPos} inside the lock in {@code RecoveryCheckpointTrigger}, ensuring that entries
+ * already delivered to channel queues before the checkpoint barrier are excluded from the disk
+ * portion.
+ *
+ * <p>The real iteration logic (seeking to {@link StartPos} and reading entries) is introduced in
+ * Phase 4. This skeleton provides the type declarations and the {@link #empty()} factory used by
+ * the feature-off code path.
+ */
+@Internal
+public final class DiskSnapshot implements CloseableIterator<DiskSnapshot.Chunk> {
+
+    /**
+     * A single recovered-state entry read from the spill file, belonging to one input channel.
+     */
+    public static final class Chunk {
+        /** The channel this entry belongs to. */
+        public final InputChannelInfo channelInfo;
+        /** Raw bytes of the recovered buffer. */
+        public final byte[] data;
+        /** Number of valid bytes in {@link #data}. */
+        public final int length;
+
+        Chunk(InputChannelInfo channelInfo, byte[] data, int length) {
+            this.channelInfo = channelInfo;
+            this.data = data;
+            this.length = length;
+        }
+    }
+
+    /**
+     * The position within the spill file at which this snapshot begins. Captured atomically inside
+     * {@code SpillFileReader.lock} at the same instant that the {@link RecoveryCheckpointBarrier}
+     * sentinels are inserted into the channel queues. This guarantees that the disk and memory
+     * portions of the snapshot are disjoint and together cover all entries exactly once.
+     *
+     * <p>Phase 4 fills in the real seek logic; this skeleton declares the type so that the
+     * interface contract can be established without churn.
+     */
+    public static final class StartPos {
+        /** Index of the spill-file segment that is current at snapshot time. */
+        public final int segmentIndex;
+        /** Byte offset within that segment at snapshot time. */
+        public final long offset;
+
+        public StartPos(int segmentIndex, long offset) {
+            this.segmentIndex = segmentIndex;
+            this.offset = offset;
+        }
+    }
+
+    private static final DiskSnapshot EMPTY_INSTANCE = new DiskSnapshot();
+
+    /**
+     * Returns a {@code DiskSnapshot} over an empty range: {@link #hasNext()} is always
+     * {@code false}, {@link #next()} always throws {@link NoSuchElementException}, and
+     * {@link #close()} is a no-op. Used by the feature-off code path where no spill file exists.
+     *
+     * @return the shared empty instance
+     */
+    public static DiskSnapshot empty() {
+        return EMPTY_INSTANCE;
+    }
+
+    /**
+     * Default constructor. At this skeleton phase the instance is always in the empty state;
+     * Phase 4 will introduce the constructor that accepts a {@link StartPos} and the spill-file
+     * handle.
+     */
+    DiskSnapshot() {}
+
+    @Override
+    public boolean hasNext() {
+        return false;
+    }
+
+    @Override
+    public Chunk next() {
+        throw new NoSuchElementException("DiskSnapshot is empty");
+    }
+
+    @Override
+    public void close() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferWriter.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Accumulates filter-phase output into a single reusable post-filter {@link Buffer} and flushes to
+ * a {@link SpillFile} once the post-filter buffer fills up. Combined with a stable pre-filter
+ * buffer instance, this bounds the filter-phase memory footprint to a constant.
+ *
+ * <p>Single-writer invariant — every mutating method (notably {@link #write}) assumes the {@code
+ * channelIOExecutor} is the sole caller. No internal synchronization is performed.
+ */
+@Internal
+public final class FilteredBufferWriter implements Closeable {
+
+    /**
+     * Hook used to obtain a fresh post-filter buffer once the active one has been flushed. The
+     * filter-phase memory bound assumes this never falls back to an unbounded heap allocation; the
+     * call may block until a pooled buffer becomes available.
+     */
+    public interface BufferPoolHook {
+        /**
+         * Returns the next post-filter buffer to accumulate into. Blocks until a buffer is
+         * available; must not silently widen the memory budget by returning heap-allocated buffers.
+         */
+        Buffer requestPostfilterBuffer() throws InterruptedException, IOException;
+    }
+
+    private final SpillFile spillFile;
+    private final Buffer prefilterBuffer;
+    private final BufferPoolHook bufferPoolHook;
+
+    // The active post-filter accumulator. Replaced (via the hook) on every flush — but the
+    // previous instance is recycled before the new one starts receiving bytes, so the in-flight
+    // count is still bounded by 1.
+    private Buffer postfilterBuffer;
+
+    // Channel that wrote the bytes currently sitting in postfilterBuffer. Used to stamp a residual
+    // flush at close() time with the correct channel identity. Reset to null after every flush.
+    private InputChannelInfo activeChannel;
+
+    private boolean closed = false;
+
+    public FilteredBufferWriter(
+            SpillFile spillFile,
+            Buffer prefilterBuffer,
+            Buffer initialPostfilterBuffer,
+            BufferPoolHook bufferPoolHook) {
+        this.spillFile = checkNotNull(spillFile);
+        this.prefilterBuffer = checkNotNull(prefilterBuffer);
+        this.postfilterBuffer = checkNotNull(initialPostfilterBuffer);
+        this.bufferPoolHook = checkNotNull(bufferPoolHook);
+    }
+
+    /**
+     * Returns the stable pre-filter buffer instance. Callers (typically {@code
+     * ChannelStateFilteringHandler.filterAndRewrite}'s buffer supplier) get the same reference on
+     * every call so that filter output never expands the working-set buffer count.
+     */
+    public Buffer getPrefilterBuffer() {
+        return prefilterBuffer;
+    }
+
+    /**
+     * Appends {@code buf}'s readable bytes to the active post-filter buffer, flushing and rotating
+     * whenever the accumulator fills up. A single {@code write} call can produce multiple {@link
+     * SpillFile} entries when the source bytes span more than one post-filter buffer.
+     *
+     * <p>The caller retains ownership of {@code buf}; bytes are copied into the accumulator.
+     *
+     * @throws IllegalStateException if {@link #close()} has already been called.
+     */
+    public void write(InputChannelInfo channelInfo, Buffer buf)
+            throws IOException, InterruptedException {
+        if (closed) {
+            throw new IllegalStateException("Cannot write to a closed FilteredBufferWriter.");
+        }
+        checkNotNull(channelInfo);
+        checkNotNull(buf);
+
+        int sourceOffset = buf.getReaderIndex();
+        int remaining = buf.readableBytes();
+        while (remaining > 0) {
+            int free = freeCapacity(postfilterBuffer);
+            if (free == 0) {
+                // Active accumulator is already full from a previous write — flush before copying
+                // any more bytes so we never reject input that would otherwise fit after rotation.
+                rotatePostfilterBuffer();
+                free = freeCapacity(postfilterBuffer);
+            }
+            int toCopy = Math.min(free, remaining);
+            copyBytes(buf, sourceOffset, postfilterBuffer, toCopy);
+            activeChannel = channelInfo;
+            sourceOffset += toCopy;
+            remaining -= toCopy;
+            if (remaining > 0) {
+                // More source bytes than the post-filter can hold: flush the now-full accumulator
+                // and keep copying into a fresh one.
+                rotatePostfilterBuffer();
+            }
+        }
+    }
+
+    /**
+     * Flushes any remaining bytes in the active post-filter buffer, recycles it, and closes the
+     * underlying {@link SpillFile}. Idempotent — repeated calls after the first are no-ops so the
+     * facade {@code SpillFileWriter} can safely guarantee close ordering without double-close
+     * concerns on the FileChannel layer.
+     */
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        try {
+            flushActive();
+        } finally {
+            try {
+                if (postfilterBuffer != null) {
+                    postfilterBuffer.recycleBuffer();
+                    postfilterBuffer = null;
+                }
+            } finally {
+                spillFile.close();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Internal helpers
+    // ---------------------------------------------------------------------------------------
+
+    /** Flushes the active post-filter buffer to the spill file and obtains a fresh one. */
+    private void rotatePostfilterBuffer() throws IOException, InterruptedException {
+        flushActive();
+        Buffer next = checkNotNull(bufferPoolHook.requestPostfilterBuffer());
+        // Defensive reset — pool implementations vary on whether they reset indices for the
+        // consumer. The accumulator must always start at size 0.
+        next.setReaderIndex(0);
+        next.setSize(0);
+        postfilterBuffer = next;
+    }
+
+    /** Writes the active accumulator's readable bytes to the spill file and recycles it. */
+    private void flushActive() throws IOException {
+        if (postfilterBuffer == null || postfilterBuffer.readableBytes() == 0) {
+            return;
+        }
+        ByteBuffer payload = postfilterBuffer.getNioBufferReadable();
+        spillFile.append(activeChannel, payload);
+        postfilterBuffer.setReaderIndex(0);
+        postfilterBuffer.setSize(0);
+        postfilterBuffer.recycleBuffer();
+        postfilterBuffer = null;
+        activeChannel = null;
+    }
+
+    private static int freeCapacity(Buffer buf) {
+        return buf.getMaxCapacity() - buf.getSize();
+    }
+
+    private static void copyBytes(Buffer src, int srcOffset, Buffer dst, int length) {
+        int dstWriteAt = dst.getMemorySegmentOffset() + dst.getSize();
+        // src/dst memory-segment offsets are the absolute start of the buffer's data slice; the
+        // logical reader index (passed as srcOffset) maps to absolute position by adding it.
+        src.getMemorySegment()
+                .copyTo(
+                        src.getMemorySegmentOffset() + srcOffset,
+                        dst.getMemorySegment(),
+                        dstWriteAt,
+                        length);
+        dst.setSize(dst.getSize() + length);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelBufferRequester.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelBufferRequester.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredInputChannel;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * {@link BufferRequester} that allocates from the source {@link RecoveredInputChannel}'s exclusive
+ * pool. Encapsulates the only cross-package access from {@code SpillFileReader} (in the channel
+ * package) to {@code RecoveredInputChannel}'s release primitives — every other site goes through
+ * the {@link BufferRequester} interface.
+ */
+@Internal
+final class RecoveredChannelBufferRequester implements BufferRequester {
+
+    private final Map<InputChannelInfo, RecoveredInputChannel> channelMap;
+
+    RecoveredChannelBufferRequester(Map<InputChannelInfo, RecoveredInputChannel> channelMap) {
+        this.channelMap = checkNotNull(channelMap);
+    }
+
+    @Override
+    public Buffer requestBufferBlocking(InputChannelInfo info)
+            throws InterruptedException, IOException {
+        RecoveredInputChannel ch = channelMap.get(info);
+        if (ch == null) {
+            throw new IllegalStateException("No source channel for " + info);
+        }
+        return ch.requestBufferBlocking();
+    }
+
+    @Override
+    public void releaseExclusiveBuffers() throws IOException {
+        for (RecoveredInputChannel ch : channelMap.values()) {
+            ch.releaseAllResources();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -344,16 +344,20 @@ class InputChannelRecoveredStateHandler
         return Files.createTempDirectory(Paths.get(root), "flink-channel-spill-");
     }
 
-    @VisibleForTesting
+    /**
+     * Returns the produced {@link SpillFile} after {@link #close} has been called on the filter-on
+     * path. Returns {@code null} on the filter-off path or before close. The drain phase consumes
+     * this handle once filter is fully done.
+     */
     @Nullable
-    SpillFile getProducedSpillFileForTesting() {
+    SpillFile getProducedSpillFile() {
         return producedSpillFile;
     }
 
     /**
      * Test-only accessor for the SpillFile currently held by the active {@link SpillFileWriter}.
      * Returns {@code null} on the filter-off path or before the first filter call. Distinct from
-     * {@link #getProducedSpillFileForTesting()} which is populated only after {@link #close()}.
+     * {@link #getProducedSpillFile()} which is populated only after {@link #close()}.
      */
     @VisibleForTesting
     @Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -133,14 +133,6 @@ class InputChannelRecoveredStateHandler
             InputGate[] inputGates,
             InflightDataRescalingDescriptor channelMapping,
             @Nullable ChannelStateFilteringHandler filteringHandler,
-            int memorySegmentSize) {
-        this(inputGates, channelMapping, filteringHandler, memorySegmentSize, null);
-    }
-
-    InputChannelRecoveredStateHandler(
-            InputGate[] inputGates,
-            InflightDataRescalingDescriptor channelMapping,
-            @Nullable ChannelStateFilteringHandler filteringHandler,
             int memorySegmentSize,
             @Nullable String[] spillTmpDirectories) {
         this.inputGates = inputGates;
@@ -285,14 +277,10 @@ class InputChannelRecoveredStateHandler
 
     /**
      * Lazily constructs the spill-file pipeline on the first filter call. Buffers backing the
-     * accumulator are wrapped over handler-owned heap segments with no-op recyclers so that any
+     * accumulator are wrapped over handler-owned segments with no-op recyclers so that any
      * intermediate {@code recycleBuffer()} (e.g. from {@code filterAndRewrite} on an empty-output
-     * path) does not return memory to the network pool — the segments live for the entire filter
-     * phase.
-     *
-     * <p>Phase 4 will switch these allocations to the {@code RecoveredChannelBufferRequester};
-     * Phase 3 uses self-managed heap segments so that the bounded "2 buffers per task" property
-     * holds without depending on Phase 4 plumbing.
+     * path) does not return memory to the underlying pool — the segments live for the entire filter
+     * phase and are released through {@link #close()}.
      */
     private SpillFileWriter ensureSpillFileWriter(RecoveredInputChannel channel)
             throws IOException, InterruptedException {
@@ -318,12 +306,10 @@ class InputChannelRecoveredStateHandler
                         prefilter,
                         initialPostfilter,
                         () -> {
-                            // Phase 3 cap: only one post-filter buffer is allocated; if the
-                            // accumulator ever needs to rotate, it indicates filter output exceeds
-                            // a single buffer worth of data, which Phase 4 will support via the
-                            // RecoveredChannelBufferRequester. Returning the same segment wrapped
-                            // in a fresh NetworkBuffer keeps the bound at two buffers total while
-                            // preserving the rotate-and-flush semantics inside the accumulator.
+                            // The accumulator only owns one post-filter buffer at any moment;
+                            // rotation re-wraps the same underlying segment in a fresh
+                            // NetworkBuffer so the working-set memory footprint stays at
+                            // one prefilter + one postfilter buffer for the whole filter phase.
                             return new NetworkBuffer(filterPostfilterSegment, resetOnlyRecycler);
                         });
         spillFileWriter = new SpillFileWriter(spillFile, accumulator);
@@ -339,15 +325,15 @@ class InputChannelRecoveredStateHandler
         }
         // A fresh subdirectory per handler instance keeps concurrent recoveries (and re-recoveries
         // on the same JVM) isolated. The directory is purposely *not* deleted on close — drain
-        // consumes the produced files; deletion is governed by a ref-counted lifecycle introduced
-        // in a later phase.
+        // consumes the produced files; deletion is governed by the ref-counted lifecycle in
+        // SpillFile (acquire/release pairs).
         return Files.createTempDirectory(Paths.get(root), "flink-channel-spill-");
     }
 
     /**
      * Returns the produced {@link SpillFile} after {@link #close} has been called on the filter-on
-     * path. Returns {@code null} on the filter-off path or before close. The drain phase consumes
-     * this handle once filter is fully done.
+     * path. Returns {@code null} on the filter-off path or before close. The drain consumes this
+     * handle once filter is fully done.
      */
     @Nullable
     SpillFile getProducedSpillFile() {
@@ -368,8 +354,8 @@ class InputChannelRecoveredStateHandler
     @Override
     public void close() throws IOException {
         // Filter-phase spill file must be frozen before any channel sees finishReadRecoveredState
-        // — the latter completes bufferFilteringCompleteFuture on every channel, and Phase 4
-        // drain is allowed to assume the spill file is closed by the time that future fires.
+        // — the latter completes bufferFilteringCompleteFuture on every channel, and the drain
+        // is allowed to assume the spill file is closed by the time that future fires.
         if (spillFileWriter != null) {
             SpillFile produced = spillFileWriter.getSpillFile();
             try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -39,6 +39,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,6 +95,13 @@ class InputChannelRecoveredStateHandler
     private final int memorySegmentSize;
 
     /**
+     * Optional list of root tmp directories used to locate the spill-file base directory in
+     * filtering mode. Falls back to the JVM's {@code java.io.tmpdir} when {@code null} or empty —
+     * the spill file lives only for the filter phase so any writable location is acceptable.
+     */
+    @Nullable private final String[] spillTmpDirectories;
+
+    /**
      * Reusable heap memory segment backing the pre-filter buffer in filtering mode. Lazily
      * allocated on the first {@link #getPreFilterBuffer} call, reused for every subsequent call,
      * and freed in {@link #close()}.
@@ -108,17 +118,38 @@ class InputChannelRecoveredStateHandler
      */
     private boolean preFilterBufferInUse;
 
+    /**
+     * Lazily constructed on the first filter-phase call so that the buffers backing the accumulator
+     * can be drawn from a real {@link RecoveredInputChannel}'s pool. {@code null} on the filter-off
+     * path. Stays alive for the duration of the filter phase; closed (and the underlying {@link
+     * SpillFile} frozen) before {@link #close()} signals filtering completion.
+     */
+    @Nullable private SpillFileWriter spillFileWriter;
+
+    /** Frozen handle to the produced {@link SpillFile}, populated by {@link #close()}. */
+    @Nullable private SpillFile producedSpillFile;
+
     InputChannelRecoveredStateHandler(
             InputGate[] inputGates,
             InflightDataRescalingDescriptor channelMapping,
             @Nullable ChannelStateFilteringHandler filteringHandler,
             int memorySegmentSize) {
+        this(inputGates, channelMapping, filteringHandler, memorySegmentSize, null);
+    }
+
+    InputChannelRecoveredStateHandler(
+            InputGate[] inputGates,
+            InflightDataRescalingDescriptor channelMapping,
+            @Nullable ChannelStateFilteringHandler filteringHandler,
+            int memorySegmentSize,
+            @Nullable String[] spillTmpDirectories) {
         this.inputGates = inputGates;
         this.channelMapping = channelMapping;
         this.filteringHandler = filteringHandler;
         checkArgument(
                 memorySegmentSize > 0, "memorySegmentSize must be positive: %s", memorySegmentSize);
         this.memorySegmentSize = memorySegmentSize;
+        this.spillTmpDirectories = spillTmpDirectories;
     }
 
     @Override
@@ -211,18 +242,29 @@ class InputChannelRecoveredStateHandler
             Buffer retainedBuffer)
             throws IOException, InterruptedException {
         checkState(filteringHandler != null, "filtering handler not set.");
+        SpillFileWriter writer = ensureSpillFileWriter(channel);
+        FilteredBufferWriter accumulator = writer.getAccumulator();
+
         List<Buffer> filteredBuffers =
                 filteringHandler.filterAndRewrite(
                         channelInfo.getGateIdx(),
                         oldSubtaskIndex,
                         channelInfo.getInputChannelIdx(),
                         retainedBuffer,
-                        channel::requestBufferBlocking);
+                        accumulator::getPrefilterBuffer);
 
         int i = 0;
         try {
             for (; i < filteredBuffers.size(); i++) {
-                channel.onRecoveredStateBuffer(filteredBuffers.get(i));
+                Buffer filtered = filteredBuffers.get(i);
+                try {
+                    writer.write(channelInfo, filtered);
+                } finally {
+                    // The accumulator copies bytes into its post-filter buffer, so the supplier-
+                    // owned filtered buffer can be recycled immediately after each write — keeping
+                    // the supplier's buffer pool free for the next allocation.
+                    filtered.recycleBuffer();
+                }
             }
         } catch (Throwable t) {
             for (int j = i; j < filteredBuffers.size(); j++) {
@@ -232,8 +274,115 @@ class InputChannelRecoveredStateHandler
         }
     }
 
+    /**
+     * Heap-backed segments owned by this handler, retained across the filter phase so that the
+     * pre-filter and post-filter buffers can survive intermediate {@code recycleBuffer()} calls
+     * from the filter without returning memory to the network pool. Freed in {@link #close()}.
+     */
+    @Nullable private MemorySegment filterPrefilterSegment;
+
+    @Nullable private MemorySegment filterPostfilterSegment;
+
+    /**
+     * Lazily constructs the spill-file pipeline on the first filter call. Buffers backing the
+     * accumulator are wrapped over handler-owned heap segments with no-op recyclers so that any
+     * intermediate {@code recycleBuffer()} (e.g. from {@code filterAndRewrite} on an empty-output
+     * path) does not return memory to the network pool — the segments live for the entire filter
+     * phase.
+     *
+     * <p>Phase 4 will switch these allocations to the {@code RecoveredChannelBufferRequester};
+     * Phase 3 uses self-managed heap segments so that the bounded "2 buffers per task" property
+     * holds without depending on Phase 4 plumbing.
+     */
+    private SpillFileWriter ensureSpillFileWriter(RecoveredInputChannel channel)
+            throws IOException, InterruptedException {
+        if (spillFileWriter != null) {
+            return spillFileWriter;
+        }
+        Path baseDir = resolveSpillBaseDir();
+        SpillFile spillFile = new SpillFile(baseDir);
+
+        filterPrefilterSegment = MemorySegmentFactory.allocateUnpooledSegment(memorySegmentSize);
+        filterPostfilterSegment = MemorySegmentFactory.allocateUnpooledSegment(memorySegmentSize);
+        BufferRecycler resetOnlyRecycler =
+                segment -> {
+                    // No-op: handler retains ownership of the heap segment for the duration of
+                    // the filter phase. The segment is freed in close().
+                };
+        Buffer prefilter = new NetworkBuffer(filterPrefilterSegment, resetOnlyRecycler);
+        Buffer initialPostfilter = new NetworkBuffer(filterPostfilterSegment, resetOnlyRecycler);
+
+        FilteredBufferWriter accumulator =
+                new FilteredBufferWriter(
+                        spillFile,
+                        prefilter,
+                        initialPostfilter,
+                        () -> {
+                            // Phase 3 cap: only one post-filter buffer is allocated; if the
+                            // accumulator ever needs to rotate, it indicates filter output exceeds
+                            // a single buffer worth of data, which Phase 4 will support via the
+                            // RecoveredChannelBufferRequester. Returning the same segment wrapped
+                            // in a fresh NetworkBuffer keeps the bound at two buffers total while
+                            // preserving the rotate-and-flush semantics inside the accumulator.
+                            return new NetworkBuffer(filterPostfilterSegment, resetOnlyRecycler);
+                        });
+        spillFileWriter = new SpillFileWriter(spillFile, accumulator);
+        return spillFileWriter;
+    }
+
+    private Path resolveSpillBaseDir() throws IOException {
+        String root;
+        if (spillTmpDirectories != null && spillTmpDirectories.length > 0) {
+            root = spillTmpDirectories[0];
+        } else {
+            root = System.getProperty("java.io.tmpdir");
+        }
+        // A fresh subdirectory per handler instance keeps concurrent recoveries (and re-recoveries
+        // on the same JVM) isolated. The directory is purposely *not* deleted on close — drain
+        // consumes the produced files; deletion is governed by a ref-counted lifecycle introduced
+        // in a later phase.
+        return Files.createTempDirectory(Paths.get(root), "flink-channel-spill-");
+    }
+
+    @VisibleForTesting
+    @Nullable
+    SpillFile getProducedSpillFileForTesting() {
+        return producedSpillFile;
+    }
+
+    /**
+     * Test-only accessor for the SpillFile currently held by the active {@link SpillFileWriter}.
+     * Returns {@code null} on the filter-off path or before the first filter call. Distinct from
+     * {@link #getProducedSpillFileForTesting()} which is populated only after {@link #close()}.
+     */
+    @VisibleForTesting
+    @Nullable
+    SpillFile peekActiveSpillFileForTesting() {
+        return spillFileWriter == null ? null : spillFileWriter.getSpillFile();
+    }
+
     @Override
     public void close() throws IOException {
+        // Filter-phase spill file must be frozen before any channel sees finishReadRecoveredState
+        // — the latter completes bufferFilteringCompleteFuture on every channel, and Phase 4
+        // drain is allowed to assume the spill file is closed by the time that future fires.
+        if (spillFileWriter != null) {
+            SpillFile produced = spillFileWriter.getSpillFile();
+            try {
+                spillFileWriter.close();
+            } finally {
+                producedSpillFile = produced;
+                spillFileWriter = null;
+            }
+        }
+        if (filterPrefilterSegment != null) {
+            filterPrefilterSegment.free();
+            filterPrefilterSegment = null;
+        }
+        if (filterPostfilterSegment != null) {
+            filterPostfilterSegment.free();
+            filterPostfilterSegment = null;
+        }
         // note that we need to finish all RecoveredInputChannels, not just those with state
         for (final InputGate inputGate : inputGates) {
             inputGate.finishReadRecoveredState();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -267,20 +267,24 @@ class InputChannelRecoveredStateHandler
     }
 
     /**
-     * Heap-backed segments owned by this handler, retained across the filter phase so that the
-     * pre-filter and post-filter buffers can survive intermediate {@code recycleBuffer()} calls
-     * from the filter without returning memory to the network pool. Freed in {@link #close()}.
+     * Pool-backed buffers owned by this handler, retained across the filter phase so that the
+     * prefilter and postfilter accumulator slots survive intermediate {@code recycleBuffer()} calls
+     * from the filter without returning memory to the network pool. The handler hands the
+     * accumulator a no-op-recycler wrapper over the same {@link MemorySegment}; the underlying
+     * pooled buffer is recycled (returning the segment to the pool) in {@link #close()}.
      */
-    @Nullable private MemorySegment filterPrefilterSegment;
+    @Nullable private Buffer filterPrefilterPooledBuffer;
 
-    @Nullable private MemorySegment filterPostfilterSegment;
+    @Nullable private Buffer filterPostfilterPooledBuffer;
 
     /**
-     * Lazily constructs the spill-file pipeline on the first filter call. Buffers backing the
-     * accumulator are wrapped over handler-owned segments with no-op recyclers so that any
-     * intermediate {@code recycleBuffer()} (e.g. from {@code filterAndRewrite} on an empty-output
-     * path) does not return memory to the underlying pool — the segments live for the entire filter
-     * phase and are released through {@link #close()}.
+     * Lazily constructs the spill-file pipeline on the first filter call. The two accumulator
+     * buffers are sourced from the network buffer pool via the source channel's exclusive pool — no
+     * heap fallback. Their underlying {@link MemorySegment}s are re-wrapped in {@link
+     * NetworkBuffer}s with no-op recyclers so that any intermediate {@code recycleBuffer()} (e.g.
+     * from {@code filterAndRewrite} on an empty-output path) does not return memory to the pool
+     * mid-filter — the segments live for the entire filter phase and are returned to the pool in
+     * {@link #close()} by recycling the original pooled buffers.
      */
     private SpillFileWriter ensureSpillFileWriter(RecoveredInputChannel channel)
             throws IOException, InterruptedException {
@@ -290,15 +294,21 @@ class InputChannelRecoveredStateHandler
         Path baseDir = resolveSpillBaseDir();
         SpillFile spillFile = new SpillFile(baseDir);
 
-        filterPrefilterSegment = MemorySegmentFactory.allocateUnpooledSegment(memorySegmentSize);
-        filterPostfilterSegment = MemorySegmentFactory.allocateUnpooledSegment(memorySegmentSize);
+        // Acquire two pool-backed buffers from the source channel's exclusive pool. These hold
+        // the accumulator's prefilter and postfilter memory for the whole filter phase. The
+        // working-set memory footprint stays at one prefilter + one postfilter buffer.
+        filterPrefilterPooledBuffer = channel.requestBufferBlocking();
+        filterPostfilterPooledBuffer = channel.requestBufferBlocking();
+        MemorySegment prefilterSegment = filterPrefilterPooledBuffer.getMemorySegment();
+        MemorySegment postfilterSegment = filterPostfilterPooledBuffer.getMemorySegment();
+
         BufferRecycler resetOnlyRecycler =
                 segment -> {
-                    // No-op: handler retains ownership of the heap segment for the duration of
-                    // the filter phase. The segment is freed in close().
+                    // No-op: handler retains ownership of the pooled segment for the duration of
+                    // the filter phase. The underlying pooled buffer is recycled in close().
                 };
-        Buffer prefilter = new NetworkBuffer(filterPrefilterSegment, resetOnlyRecycler);
-        Buffer initialPostfilter = new NetworkBuffer(filterPostfilterSegment, resetOnlyRecycler);
+        Buffer prefilter = new NetworkBuffer(prefilterSegment, resetOnlyRecycler);
+        Buffer initialPostfilter = new NetworkBuffer(postfilterSegment, resetOnlyRecycler);
 
         FilteredBufferWriter accumulator =
                 new FilteredBufferWriter(
@@ -310,7 +320,7 @@ class InputChannelRecoveredStateHandler
                             // rotation re-wraps the same underlying segment in a fresh
                             // NetworkBuffer so the working-set memory footprint stays at
                             // one prefilter + one postfilter buffer for the whole filter phase.
-                            return new NetworkBuffer(filterPostfilterSegment, resetOnlyRecycler);
+                            return new NetworkBuffer(postfilterSegment, resetOnlyRecycler);
                         });
         spillFileWriter = new SpillFileWriter(spillFile, accumulator);
         return spillFileWriter;
@@ -365,13 +375,13 @@ class InputChannelRecoveredStateHandler
                 spillFileWriter = null;
             }
         }
-        if (filterPrefilterSegment != null) {
-            filterPrefilterSegment.free();
-            filterPrefilterSegment = null;
+        if (filterPrefilterPooledBuffer != null) {
+            filterPrefilterPooledBuffer.recycleBuffer();
+            filterPrefilterPooledBuffer = null;
         }
-        if (filterPostfilterSegment != null) {
-            filterPostfilterSegment.free();
-            filterPostfilterSegment = null;
+        if (filterPostfilterPooledBuffer != null) {
+            filterPostfilterPooledBuffer.recycleBuffer();
+            filterPostfilterPooledBuffer = null;
         }
         // note that we need to finish all RecoveredInputChannels, not just those with state
         for (final InputGate inputGate : inputGates) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointBarrier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointBarrier.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A sentinel {@link Buffer} that carries the id of the checkpoint that triggered it. Inserted into
+ * each channel's {@code recoveredBuffers} queue by {@link RecoveryCheckpointTrigger} at Step 1 of
+ * the recovery-checkpoint protocol; consumed by the task thread at Step 2 to demarcate the
+ * in-memory portion of recovered state.
+ *
+ * <p>The sentinel lives only within a single task and is never serialised or transmitted over the
+ * network. It must not be confused with {@code CheckpointBarrier}, which is a network event
+ * serialised and transmitted across task boundaries.
+ *
+ * <p>Consumers MUST detect this sentinel via {@code instanceof RecoveryCheckpointBarrier} before
+ * calling any other {@link Buffer} method. All methods not required on the dequeue path throw
+ * {@link UnsupportedOperationException}. Methods that are called on the dequeue path return
+ * harmless defaults: {@link #isBuffer()} returns {@code false}, {@link #getDataType()} returns
+ * {@link DataType#NONE}, {@link #recycleBuffer()} is a no-op, and {@link #refCnt()} returns 1.
+ */
+@Internal
+public final class RecoveryCheckpointBarrier implements Buffer {
+
+    private final long checkpointId;
+
+    public RecoveryCheckpointBarrier(long checkpointId) {
+        this.checkpointId = checkpointId;
+    }
+
+    /**
+     * Returns the checkpoint id that triggered this sentinel.
+     *
+     * @return checkpoint id
+     */
+    public long getCheckpointId() {
+        return checkpointId;
+    }
+
+    // --- Methods safe to call on the dequeue path ---
+
+    /** Returns {@code false}: this sentinel is not a data buffer. */
+    @Override
+    public boolean isBuffer() {
+        return false;
+    }
+
+    /**
+     * Returns {@link DataType#NONE}: no routing or priority semantics apply to this sentinel;
+     * consumers must detect it via {@code instanceof} before inspecting the data type.
+     */
+    @Override
+    public DataType getDataType() {
+        return DataType.NONE;
+    }
+
+    /** No-op: the sentinel holds no pooled memory to recycle. */
+    @Override
+    public void recycleBuffer() {}
+
+    /** Returns {@code false}: the sentinel is never recycled. */
+    @Override
+    public boolean isRecycled() {
+        return false;
+    }
+
+    /** Returns {@code this}: the sentinel needs no reference counting. */
+    @Override
+    public Buffer retainBuffer() {
+        return this;
+    }
+
+    /** Returns 1: the sentinel is logically always live. */
+    @Override
+    public int refCnt() {
+        return 1;
+    }
+
+    // --- Unsupported methods: not called on the dequeue path ---
+
+    @Override
+    public MemorySegment getMemorySegment() {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no memory segment");
+    }
+
+    @Override
+    public int getMemorySegmentOffset() {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no memory segment");
+    }
+
+    @Override
+    public BufferRecycler getRecycler() {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no recycler");
+    }
+
+    @Override
+    public void setRecycler(BufferRecycler bufferRecycler) {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no recycler");
+    }
+
+    @Override
+    public Buffer readOnlySlice() {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier cannot be sliced");
+    }
+
+    @Override
+    public Buffer readOnlySlice(int index, int length) {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier cannot be sliced");
+    }
+
+    @Override
+    public int getMaxCapacity() {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no capacity");
+    }
+
+    @Override
+    public int getReaderIndex() {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no reader index");
+    }
+
+    @Override
+    public void setReaderIndex(int readerIndex) throws IndexOutOfBoundsException {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no reader index");
+    }
+
+    @Override
+    public int getSize() {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no size");
+    }
+
+    @Override
+    public void setSize(int writerIndex) {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no size");
+    }
+
+    @Override
+    public int readableBytes() {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no readable bytes");
+    }
+
+    @Override
+    public ByteBuffer getNioBufferReadable() {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no NIO buffer");
+    }
+
+    @Override
+    public ByteBuffer getNioBuffer(int index, int length) throws IndexOutOfBoundsException {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no NIO buffer");
+    }
+
+    @Override
+    public void setAllocator(ByteBufAllocator allocator) {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no allocator");
+    }
+
+    @Override
+    public ByteBuf asByteBuf() {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier cannot be a ByteBuf");
+    }
+
+    @Override
+    public boolean isCompressed() {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no compression");
+    }
+
+    @Override
+    public void setCompressed(boolean isCompressed) {
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier has no compression");
+    }
+
+    @Override
+    public void setDataType(DataType dataType) {
+        throw new UnsupportedOperationException(
+                "RecoveryCheckpointBarrier data type is immutable");
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointBarrier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointBarrier.java
@@ -194,7 +194,6 @@ public final class RecoveryCheckpointBarrier implements Buffer {
 
     @Override
     public void setDataType(DataType dataType) {
-        throw new UnsupportedOperationException(
-                "RecoveryCheckpointBarrier data type is immutable");
+        throw new UnsupportedOperationException("RecoveryCheckpointBarrier data type is immutable");
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointTrigger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointTrigger.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Implemented by {@code SpillFileReader}; the task thread holds the reference typed as this
+ * interface. Drives Step 1 of the recovery-checkpoint protocol.
+ */
+@Internal
+public interface RecoveryCheckpointTrigger {
+
+    /**
+     * Step 1 of the recovery-checkpoint protocol. Atomically:
+     *
+     * <ol>
+     *   <li>Enters {@code SpillFileReader.lock}.
+     *   <li>Snapshots every SpillFileSegment and captures {@code (currentSegmentIndex,
+     *       currentOffset)} as {@link DiskSnapshot.StartPos}.
+     *   <li>Calls {@code onRecoveredStateBuffer(new RecoveryCheckpointBarrier(checkpointId))} on
+     *       every channel of the task.
+     *   <li>Leaves the lock.
+     * </ol>
+     *
+     * <p>The {@code checkpointId} is forwarded from {@code CheckpointBarrier.getId()} by the
+     * checkpoint dispatcher (Phase 5); it is embedded in the {@link RecoveryCheckpointBarrier}
+     * sentinel so that Step 2 can correlate the barrier with the triggering checkpoint.
+     *
+     * <p>Caller (task thread) MUST NOT hold {@code SpillFileReader.lock} — the implementation
+     * takes the lock itself.
+     *
+     * <p>The returned {@link DiskSnapshot} feeds into
+     * {@link ChannelStateWriter#addInputDataFromSpill} at Step 3.
+     *
+     * @param checkpointId the id of the checkpoint being triggered
+     * @return a snapshot of the disk state at the moment of the atomic cut
+     */
+    DiskSnapshot snapshotAndInsertBarriers(long checkpointId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointTrigger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointTrigger.java
@@ -39,8 +39,8 @@ public interface RecoveryCheckpointTrigger {
      * </ol>
      *
      * <p>The {@code checkpointId} is forwarded from {@code CheckpointBarrier.getId()} by the
-     * checkpoint dispatcher (Phase 5); it is embedded in the {@link RecoveryCheckpointBarrier}
-     * sentinel so that Step 2 can correlate the barrier with the triggering checkpoint.
+     * checkpoint dispatcher; it is embedded in the {@link RecoveryCheckpointBarrier} sentinel so
+     * that Step 2 can correlate the barrier with the triggering checkpoint.
      *
      * <p>Caller (task thread) MUST NOT hold {@code SpillFileReader.lock} — the implementation takes
      * the lock itself.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointTrigger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointTrigger.java
@@ -42,11 +42,11 @@ public interface RecoveryCheckpointTrigger {
      * checkpoint dispatcher (Phase 5); it is embedded in the {@link RecoveryCheckpointBarrier}
      * sentinel so that Step 2 can correlate the barrier with the triggering checkpoint.
      *
-     * <p>Caller (task thread) MUST NOT hold {@code SpillFileReader.lock} — the implementation
-     * takes the lock itself.
+     * <p>Caller (task thread) MUST NOT hold {@code SpillFileReader.lock} — the implementation takes
+     * the lock itself.
      *
-     * <p>The returned {@link DiskSnapshot} feeds into
-     * {@link ChannelStateWriter#addInputDataFromSpill} at Step 3.
+     * <p>The returned {@link DiskSnapshot} feeds into {@link
+     * ChannelStateWriter#addInputDataFromSpill} at Step 3.
      *
      * @param checkpointId the id of the checkpoint being triggered
      * @return a snapshot of the disk state at the moment of the atomic cut

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointTrigger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointTrigger.java
@@ -52,4 +52,11 @@ public interface RecoveryCheckpointTrigger {
      * @return a snapshot of the disk state at the moment of the atomic cut
      */
     DiskSnapshot snapshotAndInsertBarriers(long checkpointId);
+
+    /**
+     * No-op singleton used on the feature-off path and once recovery has fully completed. Returning
+     * the empty {@link DiskSnapshot} singleton lets the dispatcher run Step 1 / Step 3
+     * unconditionally — there is no {@code if (filter-on)} branch at the dispatcher layer.
+     */
+    RecoveryCheckpointTrigger NO_OP = checkpointId -> DiskSnapshot.empty();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReader.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.streaming.runtime.io.recovery.RecordFilterContext;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 /** Reads channel state saved during checkpoint/savepoint. */
@@ -39,6 +41,16 @@ public interface SequentialChannelStateReader extends AutoCloseable {
 
     void readOutputData(ResultPartitionWriter[] writers, boolean notifyAndBlockOnCompletion)
             throws IOException, InterruptedException;
+
+    /**
+     * After {@link #readInputData} completes on the filter-on path, returns the produced {@link
+     * SpillFile} for the drain phase. Returns {@code null} on the filter-off path or before {@code
+     * readInputData} has produced one.
+     */
+    @Nullable
+    default SpillFile getProducedSpillFile() {
+        return null;
+    }
 
     @Override
     void close() throws Exception;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -30,6 +30,8 @@ import org.apache.flink.runtime.state.ChannelStateHelper;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.streaming.runtime.io.recovery.RecordFilterContext;
 
+import javax.annotation.Nullable;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
@@ -53,6 +55,13 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
     private final ChannelStateSerializer serializer;
     private final ChannelStateChunkReader chunkReader;
 
+    /**
+     * Frozen handle to the spill file produced during the filter phase; {@code null} when the
+     * filter-on path was not taken. Published by {@link #readInputData} after the input handler
+     * closes.
+     */
+    @Nullable private SpillFile producedSpillFile;
+
     public SequentialChannelStateReaderImpl(TaskStateSnapshot taskStateSnapshot) {
         this.taskStateSnapshot = taskStateSnapshot;
         serializer = new ChannelStateSerializerImpl();
@@ -69,31 +78,46 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                         ? ChannelStateFilteringHandler.createFromContext(filterContext, inputGates)
                         : null;
 
-        try (ChannelStateFilteringHandler ignored = filteringHandler;
-                InputChannelRecoveredStateHandler stateHandler =
-                        new InputChannelRecoveredStateHandler(
-                                inputGates,
-                                taskStateSnapshot.getInputRescalingDescriptor(),
-                                filteringHandler,
-                                filterContext.getMemorySegmentSize(),
-                                filterContext.getTmpDirectories())) {
-            read(
-                    stateHandler,
-                    groupByDelegate(
-                            streamSubtaskStates(),
-                            ChannelStateHelper::extractUnmergedInputHandles));
-            read(
-                    stateHandler,
-                    groupByDelegate(
-                            streamSubtaskStates(),
-                            OperatorSubtaskState::getUpstreamOutputBufferState));
+        // Manual close ordering so the produced spill file can be published after
+        // stateHandler.close() flushes the filter writer.
+        InputChannelRecoveredStateHandler stateHandler =
+                new InputChannelRecoveredStateHandler(
+                        inputGates,
+                        taskStateSnapshot.getInputRescalingDescriptor(),
+                        filteringHandler,
+                        filterContext.getMemorySegmentSize(),
+                        filterContext.getTmpDirectories());
+        try (ChannelStateFilteringHandler ignored = filteringHandler) {
+            try {
+                read(
+                        stateHandler,
+                        groupByDelegate(
+                                streamSubtaskStates(),
+                                ChannelStateHelper::extractUnmergedInputHandles));
+                read(
+                        stateHandler,
+                        groupByDelegate(
+                                streamSubtaskStates(),
+                                OperatorSubtaskState::getUpstreamOutputBufferState));
 
-            if (filteringHandler != null) {
-                checkState(
-                        !filteringHandler.hasPartialData(),
-                        "Not all data has been fully consumed during filtering");
+                if (filteringHandler != null) {
+                    checkState(
+                            !filteringHandler.hasPartialData(),
+                            "Not all data has been fully consumed during filtering");
+                }
+            } finally {
+                stateHandler.close();
             }
+            // After handler close: filter writer is flushed and producedSpillFile is populated
+            // on the filter-on path (null on filter-off). The drain phase consumes it from here.
+            this.producedSpillFile = stateHandler.getProducedSpillFile();
         }
+    }
+
+    @Override
+    @Nullable
+    public SpillFile getProducedSpillFile() {
+        return producedSpillFile;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -75,7 +75,8 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                                 inputGates,
                                 taskStateSnapshot.getInputRescalingDescriptor(),
                                 filteringHandler,
-                                filterContext.getMemorySegmentSize())) {
+                                filterContext.getMemorySegmentSize(),
+                                filterContext.getTmpDirectories())) {
             read(
                     stateHandler,
                     groupByDelegate(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFile.java
@@ -32,6 +32,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -157,6 +159,22 @@ public final class SpillFile implements Closeable {
     private final Deque<Entry> entries = new ArrayDeque<>();
     private boolean closed = false;
 
+    /**
+     * Number of live consumers that still need the on-disk segments: the drain reader, plus one per
+     * in-flight {@link DiskSnapshot} produced by a recovery-time checkpoint. Incremented by {@link
+     * #acquire()} and decremented by {@link #release()}. The actual segment deletion is gated by
+     * {@link #cleanedUp} so it runs at most once even when {@code release} and {@link #close()}
+     * race.
+     */
+    private final AtomicInteger refCount = new AtomicInteger(0);
+
+    /**
+     * Latches true the first time a cleanup path wins the CAS, making segment deletion idempotent
+     * across the {@code release-to-zero} path and the forced {@link #close()} path (which the
+     * shutdown / test harness needs even if some references are still outstanding).
+     */
+    private final AtomicBoolean cleanedUp = new AtomicBoolean(false);
+
     public SpillFile(Path baseDir, long segmentSizeBytes) {
         checkArgument(
                 segmentSizeBytes > 0, "segmentSizeBytes must be positive: %s", segmentSizeBytes);
@@ -249,9 +267,35 @@ public final class SpillFile implements Closeable {
     }
 
     /**
-     * Closes every segment file. Idempotent — repeated calls are no-ops, so the closure ordering
-     * inside higher-level facades ({@code SpillFileWriter}) can safely call this even after the
-     * accumulator has already closed it.
+     * Increments the reference count. Called once by the {@link SpillFileReader} constructor and
+     * once per {@link DiskSnapshot} produced at Step 1 of the recovery-checkpoint protocol. Pairs
+     * with {@link #release()}.
+     */
+    public void acquire() {
+        refCount.incrementAndGet();
+    }
+
+    /**
+     * Decrements the reference count. When the count reaches zero, attempts the one-shot segment
+     * deletion guarded by {@link #cleanedUp}. The CAS makes the deletion idempotent: concurrent
+     * {@code release()} callers that all observe zero, plus a racing forced {@link #close()}, all
+     * agree on a single cleanup. Once cleanup runs, {@link #closed} flips too so any further {@link
+     * #append} attempts fail loudly rather than write to deleted files.
+     */
+    public void release() throws IOException {
+        if (refCount.decrementAndGet() == 0) {
+            if (cleanedUp.compareAndSet(false, true)) {
+                closed = true;
+                deleteAllSegments();
+            }
+        }
+    }
+
+    /**
+     * Forced cleanup entry retained for tests and task-manager shutdown — callers may need to
+     * remove segments even if some {@link DiskSnapshot} references are still outstanding (e.g. the
+     * checkpoint they belong to was aborted before the writer future fired). Shares the {@link
+     * #cleanedUp} CAS with {@link #release()} so the actual deletion runs at most once.
      */
     @Override
     public void close() throws IOException {
@@ -259,10 +303,29 @@ public final class SpillFile implements Closeable {
             return;
         }
         closed = true;
+        if (cleanedUp.compareAndSet(false, true)) {
+            deleteAllSegments();
+        }
+    }
+
+    /**
+     * Closes every segment {@link FileChannel} and removes the underlying segment file from disk.
+     * Always invoked through the {@link #cleanedUp} CAS so it runs at most once.
+     */
+    private void deleteAllSegments() throws IOException {
         IOException firstError = null;
         for (SpillFileSegment seg : segments) {
             try {
                 seg.close();
+            } catch (IOException e) {
+                if (firstError == null) {
+                    firstError = e;
+                } else {
+                    firstError.addSuppressed(e);
+                }
+            }
+            try {
+                Files.deleteIfExists(seg.path);
             } catch (IOException e) {
                 if (firstError == null) {
                     firstError = e;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFile.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An append-only, segmented on-disk store for recovered channel-state buffers produced by the
+ * filter phase. Written by a single thread (the {@code channelIOExecutor}); records the metadata
+ * for every appended payload in an in-memory {@link Entry} queue so that the drain phase (Phase 4)
+ * can replay the payloads in order.
+ *
+ * <p>Segments rotate once a single file would exceed the configured segment size. The default size
+ * caps each segment file at 64 MiB, balancing OS-level I/O scheduling against per-segment metadata
+ * overhead.
+ *
+ * <p>Single-writer invariant — all mutating methods assume the caller is the one and only writer.
+ * No internal locking is performed; correctness relies on the {@code channelIOExecutor}'s
+ * single-thread guarantee.
+ */
+@Internal
+public final class SpillFile implements Closeable {
+
+    /**
+     * Maximum size of a single on-disk segment file before rotating to a new one. Aligned with the
+     * segment-size convention used elsewhere in the channel-state IO path.
+     */
+    public static final long DEFAULT_SEGMENT_SIZE_BYTES = 64L * 1024 * 1024;
+
+    /**
+     * One on-disk segment of a {@link SpillFile}. Holds the segment index, file path, an opened
+     * {@link FileChannel} for append-only writes, and a running byte counter.
+     */
+    static final class SpillFileSegment implements Closeable {
+        final int segmentIndex;
+        final Path path;
+        final FileChannel channel;
+        // Number of bytes written so far in this segment. Updated after every append.
+        long currentEnd;
+
+        SpillFileSegment(int segmentIndex, Path path, FileChannel channel) {
+            this.segmentIndex = segmentIndex;
+            this.path = path;
+            this.channel = channel;
+            this.currentEnd = 0L;
+        }
+
+        @Override
+        public void close() throws IOException {
+            // Closing an already-closed FileChannel is a no-op, which keeps SpillFile.close
+            // idempotent without per-segment bookkeeping.
+            channel.close();
+        }
+    }
+
+    /**
+     * A single record persisted in a {@link SpillFile}: identifies the channel, segment, and byte
+     * range of the payload. The drain phase replays the file in {@code entries} order.
+     */
+    static final class Entry {
+        final InputChannelInfo channelInfo;
+        final int segmentIndex;
+        final long offset;
+        final int length;
+
+        Entry(InputChannelInfo channelInfo, int segmentIndex, long offset, int length) {
+            this.channelInfo = channelInfo;
+            this.segmentIndex = segmentIndex;
+            this.offset = offset;
+            this.length = length;
+        }
+    }
+
+    private final Path baseDir;
+    private final long segmentSizeBytes;
+    private final List<SpillFileSegment> segments = new ArrayList<>();
+    private final Deque<Entry> entries = new ArrayDeque<>();
+    private boolean closed = false;
+
+    public SpillFile(Path baseDir, long segmentSizeBytes) {
+        checkArgument(
+                segmentSizeBytes > 0, "segmentSizeBytes must be positive: %s", segmentSizeBytes);
+        this.baseDir = checkNotNull(baseDir);
+        this.segmentSizeBytes = segmentSizeBytes;
+    }
+
+    public SpillFile(Path baseDir) {
+        this(baseDir, DEFAULT_SEGMENT_SIZE_BYTES);
+    }
+
+    /**
+     * Append a single payload for {@code channelInfo}. The payload is written from {@code
+     * payload.position()} to {@code payload.limit()}; on return the payload's position is advanced
+     * past the written bytes (standard {@link FileChannel#write(ByteBuffer)} semantics).
+     *
+     * <p>If writing the payload would push the active segment past {@link #segmentSizeBytes}, a new
+     * segment is created first. A single payload is never split across segments — the recovered
+     * buffer size is bounded by a single network buffer (well below 64 MiB), so segment rotation
+     * happens cleanly between records.
+     *
+     * @throws IllegalStateException if {@link #close()} has been called.
+     */
+    public void append(InputChannelInfo channelInfo, ByteBuffer payload) throws IOException {
+        if (closed) {
+            throw new IllegalStateException(
+                    "Cannot append to a closed SpillFile (baseDir=" + baseDir + ").");
+        }
+        checkNotNull(channelInfo);
+        checkNotNull(payload);
+
+        int length = payload.remaining();
+        if (length == 0) {
+            // Empty payloads produce no on-disk effect and no entry — keeping entry semantics
+            // strictly "one entry == one non-empty record".
+            return;
+        }
+
+        SpillFileSegment active = activeSegmentFor(length);
+        long offsetBeforeWrite = active.currentEnd;
+
+        int written = 0;
+        while (written < length) {
+            int n = active.channel.write(payload);
+            // FileChannel.write never returns negative for a regular file; guard defensively.
+            if (n <= 0) {
+                throw new IOException(
+                        "FileChannel.write returned " + n + " on segment " + active.path);
+            }
+            written += n;
+        }
+        active.currentEnd = offsetBeforeWrite + length;
+        entries.add(new Entry(channelInfo, active.segmentIndex, offsetBeforeWrite, length));
+    }
+
+    /**
+     * Returns the segment to write the next payload into, rotating to a fresh segment when adding
+     * {@code payloadLength} bytes would exceed {@link #segmentSizeBytes}. Allocates the first
+     * segment lazily on the first call.
+     */
+    private SpillFileSegment activeSegmentFor(int payloadLength) throws IOException {
+        if (segments.isEmpty()) {
+            return openNewSegment();
+        }
+        SpillFileSegment current = segments.get(segments.size() - 1);
+        if (current.currentEnd + payloadLength > segmentSizeBytes) {
+            return openNewSegment();
+        }
+        return current;
+    }
+
+    private SpillFileSegment openNewSegment() throws IOException {
+        Files.createDirectories(baseDir);
+        int index = segments.size();
+        Path segmentPath = baseDir.resolve("spill-segment-" + index + ".bin");
+        FileChannel channel =
+                FileChannel.open(
+                        segmentPath,
+                        StandardOpenOption.CREATE_NEW,
+                        StandardOpenOption.WRITE,
+                        StandardOpenOption.READ);
+        SpillFileSegment seg = new SpillFileSegment(index, segmentPath, channel);
+        segments.add(seg);
+        return seg;
+    }
+
+    /**
+     * Closes every segment file. Idempotent — repeated calls are no-ops, so the closure ordering
+     * inside higher-level facades ({@code SpillFileWriter}) can safely call this even after the
+     * accumulator has already closed it.
+     */
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        IOException firstError = null;
+        for (SpillFileSegment seg : segments) {
+            try {
+                seg.close();
+            } catch (IOException e) {
+                if (firstError == null) {
+                    firstError = e;
+                } else {
+                    firstError.addSuppressed(e);
+                }
+            }
+        }
+        if (firstError != null) {
+            throw firstError;
+        }
+    }
+
+    @VisibleForTesting
+    public boolean isClosed() {
+        return closed;
+    }
+
+    /**
+     * Returns an unmodifiable view of the entry queue. Package-private so callers in this package
+     * (Phase 4 drain, tests) can inspect the disk layout without touching internal state.
+     */
+    List<Entry> entries() {
+        return Collections.unmodifiableList(new ArrayList<>(entries));
+    }
+
+    /** Returns an unmodifiable snapshot of the current segment list. */
+    List<SpillFileSegment> segments() {
+        return Collections.unmodifiableList(segments);
+    }
+
+    /**
+     * Reads {@code length} bytes from {@code segmentIndex} starting at {@code offset} into a fresh
+     * byte array. Exists primarily so tests and Phase 4 drain code can verify on-disk content
+     * without re-implementing the segment lookup. Reads the open file channel directly via a
+     * position-based read so concurrent appends (single-writer guarantee aside) cannot affect the
+     * channel's logical position.
+     */
+    byte[] readBytes(int segmentIndex, long offset, int length) throws IOException {
+        checkArgument(
+                segmentIndex >= 0 && segmentIndex < segments.size(),
+                "segmentIndex out of range: %s",
+                segmentIndex);
+        checkArgument(length >= 0, "length must be non-negative: %s", length);
+
+        SpillFileSegment seg = segments.get(segmentIndex);
+        ByteBuffer buf = ByteBuffer.allocate(length);
+        int totalRead = 0;
+        while (totalRead < length) {
+            int n = seg.channel.read(buf, offset + totalRead);
+            if (n < 0) {
+                throw new IOException(
+                        "Unexpected EOF reading segment "
+                                + seg.path
+                                + " at offset "
+                                + (offset + totalRead));
+            }
+            totalRead += n;
+        }
+        return buf.array();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFile.java
@@ -41,8 +41,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * An append-only, segmented on-disk store for recovered channel-state buffers produced by the
  * filter phase. Written by a single thread (the {@code channelIOExecutor}); records the metadata
- * for every appended payload in an in-memory {@link Entry} queue so that the drain phase (Phase 4)
- * can replay the payloads in order.
+ * for every appended payload in an in-memory {@link Entry} queue so that the drain can replay the
+ * payloads in order.
  *
  * <p>Segments rotate once a single file would exceed the configured segment size. The default size
  * caps each segment file at 64 MiB, balancing OS-level I/O scheduling against per-segment metadata
@@ -346,7 +346,7 @@ public final class SpillFile implements Closeable {
 
     /**
      * Returns an unmodifiable view of the entry queue. Package-private so callers in this package
-     * (Phase 4 drain, tests) can inspect the disk layout without touching internal state.
+     * (drain, tests) can inspect the disk layout without touching internal state.
      */
     List<Entry> entries() {
         return Collections.unmodifiableList(new ArrayList<>(entries));
@@ -400,10 +400,10 @@ public final class SpillFile implements Closeable {
 
     /**
      * Reads {@code length} bytes from {@code segmentIndex} starting at {@code offset} into a fresh
-     * byte array. Exists primarily so tests and Phase 4 drain code can verify on-disk content
-     * without re-implementing the segment lookup. Reads the open file channel directly via a
-     * position-based read so concurrent appends (single-writer guarantee aside) cannot affect the
-     * channel's logical position.
+     * byte array. Exists primarily so tests and drain code can verify on-disk content without
+     * re-implementing the segment lookup. Reads the open file channel directly via a position-based
+     * read so concurrent appends (single-writer guarantee aside) cannot affect the channel's
+     * logical position.
      */
     byte[] readBytes(int segmentIndex, long offset, int length) throws IOException {
         checkArgument(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFile.java
@@ -62,6 +62,12 @@ public final class SpillFile implements Closeable {
     /**
      * One on-disk segment of a {@link SpillFile}. Holds the segment index, file path, an opened
      * {@link FileChannel} for append-only writes, and a running byte counter.
+     *
+     * <p>Drain ({@code SpillFileReader}) maintains a private peek/poll cursor over the entries
+     * belonging to this segment so that read progress can be advanced atomically with the channel
+     * delivery inside {@code SpillFileReader.lock}. Each {@link #readBytesAt} call opens an
+     * independent read-only {@link FileChannel} so that the drain and any concurrent in-recovery
+     * checkpoint readers never share file position state.
      */
     static final class SpillFileSegment implements Closeable {
         final int segmentIndex;
@@ -70,11 +76,53 @@ public final class SpillFile implements Closeable {
         // Number of bytes written so far in this segment. Updated after every append.
         long currentEnd;
 
+        // Drain-side cursor over the entries that belong to this segment. Populated by the
+        // enclosing SpillFile after filter completes; consumed by drain. Not used by readers
+        // opened over a SpillFile.Snapshot — those iterate via their own cursor.
+        private final Deque<Entry> drainEntries = new ArrayDeque<>();
+
         SpillFileSegment(int segmentIndex, Path path, FileChannel channel) {
             this.segmentIndex = segmentIndex;
             this.path = path;
             this.channel = channel;
             this.currentEnd = 0L;
+        }
+
+        /** Returns the next entry to drain without removing it, or {@code null} when empty. */
+        Entry peekNextEntry() {
+            return drainEntries.peek();
+        }
+
+        /** Removes and returns the next entry to drain, or {@code null} when empty. */
+        Entry pollNextEntry() {
+            return drainEntries.poll();
+        }
+
+        /**
+         * Reads {@code length} bytes from {@code offset} into {@code dest} using an independently
+         * opened read-only {@link FileChannel}. A fresh handle per call avoids sharing position
+         * state with the segment's append-side handle and with any other concurrent reader (drain
+         * and the per-checkpoint readers can call this in parallel).
+         */
+        void readBytesAt(long offset, int length, byte[] dest) throws IOException {
+            checkArgument(length >= 0, "length must be non-negative: %s", length);
+            checkArgument(
+                    dest.length >= length, "dest buffer too small: %s < %s", dest.length, length);
+            try (FileChannel reader = FileChannel.open(path, StandardOpenOption.READ)) {
+                ByteBuffer view = ByteBuffer.wrap(dest, 0, length);
+                int totalRead = 0;
+                while (totalRead < length) {
+                    int n = reader.read(view, offset + totalRead);
+                    if (n < 0) {
+                        throw new IOException(
+                                "Unexpected EOF reading segment "
+                                        + path
+                                        + " at offset "
+                                        + (offset + totalRead));
+                    }
+                    totalRead += n;
+                }
+            }
         }
 
         @Override
@@ -161,7 +209,12 @@ public final class SpillFile implements Closeable {
             written += n;
         }
         active.currentEnd = offsetBeforeWrite + length;
-        entries.add(new Entry(channelInfo, active.segmentIndex, offsetBeforeWrite, length));
+        Entry entry = new Entry(channelInfo, active.segmentIndex, offsetBeforeWrite, length);
+        entries.add(entry);
+        // Mirror into the per-segment drain queue so SpillFileReader can peek/poll without
+        // re-grouping. Filter is single-writer; appending here observes the same single-writer
+        // invariant.
+        active.drainEntries.add(entry);
     }
 
     /**
@@ -239,6 +292,47 @@ public final class SpillFile implements Closeable {
     /** Returns an unmodifiable snapshot of the current segment list. */
     List<SpillFileSegment> segments() {
         return Collections.unmodifiableList(segments);
+    }
+
+    /**
+     * Returns an immutable point-in-time view of the file's metadata: a shallow copy of the segment
+     * list plus a defensive copy of the entry queue. Both lists are exposed as unmodifiable. Filter
+     * is the single writer of {@link #entries} and {@link SpillFileSegment#currentEnd}; once filter
+     * has completed (the only legitimate moment to call this method), neither changes, so the
+     * shallow segment copy is a stable read-only view of the on-disk layout.
+     *
+     * <p>Callers are expected to be on the task thread inside {@code SpillFileReader.lock}. The
+     * method itself does no synchronisation — atomicity with the drain progress fields is the
+     * caller's responsibility.
+     */
+    public Snapshot snapshot() {
+        return new Snapshot(new ArrayList<>(segments), new ArrayList<>(entries));
+    }
+
+    /**
+     * Immutable view of a {@link SpillFile} produced by {@link #snapshot()}. Used by the
+     * per-checkpoint readers ({@link DiskSnapshot}) to iterate the disk slice without touching the
+     * live writer state. The lists are unmodifiable; segments themselves remain shared with the
+     * underlying {@link SpillFile} since they are no longer mutated after filter completes.
+     */
+    public static final class Snapshot {
+        private final List<SpillFileSegment> segments;
+        private final List<Entry> entries;
+
+        Snapshot(List<SpillFileSegment> segments, List<Entry> entries) {
+            this.segments = Collections.unmodifiableList(segments);
+            this.entries = Collections.unmodifiableList(entries);
+        }
+
+        /** Returns the segments captured at snapshot time, in segment-index order. */
+        public List<SpillFileSegment> getSegments() {
+            return segments;
+        }
+
+        /** Returns the entries captured at snapshot time, in append order. */
+        public List<Entry> getEntries() {
+            return entries;
+        }
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReader.java
@@ -67,19 +67,22 @@ public final class SpillFileReader implements RecoveryCheckpointTrigger, Closeab
     private long currentOffset = 0L;
 
     /**
-     * Constructs the reader from a frozen spill file and the physical channel set of the task. The
-     * map is derived from the same set (caller-provided so that the implementation does not need to
-     * downcast {@link RecoverableInputChannel} to retrieve {@code InputChannelInfo}).
+     * Constructs the reader from a frozen spill file and the physical channel set of the task.
+     * Derives the {@code InputChannelInfo}-keyed map internally via {@link
+     * RecoverableInputChannel#getChannelInfo()}.
      */
     public SpillFileReader(
             SpillFile spillFile,
             List<RecoverableInputChannel> allChannels,
-            Map<InputChannelInfo, RecoverableInputChannel> channelByInfo,
             BufferRequester bufferRequester) {
         this.spillFile = checkNotNull(spillFile);
         this.allChannels = checkNotNull(allChannels);
-        this.channelByInfo = new HashMap<>(checkNotNull(channelByInfo));
         this.bufferRequester = checkNotNull(bufferRequester);
+        Map<InputChannelInfo, RecoverableInputChannel> byInfo = new HashMap<>();
+        for (RecoverableInputChannel ch : allChannels) {
+            byInfo.put(ch.getChannelInfo(), ch);
+        }
+        this.channelByInfo = byInfo;
         // Drain holds one ref-count grant for the lifetime of this reader; matched by close().
         spillFile.acquire();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReader.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoverableInputChannel;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Drives the drain phase of the recovery-checkpoint protocol: replays each entry of a frozen {@link
+ * SpillFile} into the corresponding physical channel's {@code recoveredBuffers} queue, and serves
+ * the task-thread Step 1 trigger via {@link RecoveryCheckpointTrigger}.
+ *
+ * <p>Concurrency model — a single private {@code Object lock} guards three things together: (a)
+ * per-entry channel delivery via {@code onRecoveredStateBuffer}; (b) advancing {@code
+ * currentSegmentIndex} / {@code currentOffset}; (c) the Step 1 disk snapshot plus per-channel
+ * barrier insert. Inside drain, buffer allocation and the disk read run OUTSIDE the lock — the lock
+ * is only taken to deliver the buffer into the channel and update the drain progress fields in a
+ * single atomic action. End-of-drain {@code finishReadRecoveredState} runs outside the lock; at
+ * that point no more buffers are being added so the (queue, offset) atomicity does not apply.
+ */
+@Internal
+public final class SpillFileReader implements RecoveryCheckpointTrigger, Closeable {
+
+    private final SpillFile spillFile;
+    private final List<RecoverableInputChannel> allChannels;
+    private final Map<InputChannelInfo, RecoverableInputChannel> channelByInfo;
+    private final BufferRequester bufferRequester;
+
+    /**
+     * Named lock (not the implicit {@code this} monitor) so it is grep-able and {@link
+     * GuardedBy}-annotated. Drain holds it microsecond-scale per entry; task thread holds it once
+     * per checkpoint trigger. Lock order: {@code SpillFileReader.lock → channel-internal queue
+     * monitor}.
+     */
+    private final Object lock = new Object();
+
+    @GuardedBy("lock")
+    private int currentSegmentIndex = 0;
+
+    @GuardedBy("lock")
+    private long currentOffset = 0L;
+
+    /**
+     * Constructs the reader from a frozen spill file and the physical channel set of the task. The
+     * map is derived from the same set (caller-provided so that the implementation does not need to
+     * downcast {@link RecoverableInputChannel} to retrieve {@code InputChannelInfo}).
+     */
+    public SpillFileReader(
+            SpillFile spillFile,
+            List<RecoverableInputChannel> allChannels,
+            Map<InputChannelInfo, RecoverableInputChannel> channelByInfo,
+            BufferRequester bufferRequester) {
+        this.spillFile = checkNotNull(spillFile);
+        this.allChannels = checkNotNull(allChannels);
+        this.channelByInfo = new HashMap<>(checkNotNull(channelByInfo));
+        this.bufferRequester = checkNotNull(bufferRequester);
+    }
+
+    /**
+     * Drains every entry in the underlying spill file sequentially. Called by the {@code
+     * channelIOExecutor} after conversion completes. Buffer allocation (A) and disk read (B) happen
+     * outside the lock. Only the two-statement critical section (C) — channel deliver plus
+     * drain-progress advance — is inside the lock. End-of-drain {@code finishReadRecoveredState}
+     * (D) is outside the lock: no more buffers are being added at that point, so the (queue,
+     * offset) atomicity that the lock protects does not apply.
+     */
+    public void drain() throws IOException, InterruptedException {
+        for (SpillFile.SpillFileSegment seg : spillFile.segments()) {
+            SpillFile.Entry e;
+            // Peek runs outside the lock: filter completed before drain started, so the per-
+            // segment entry queue is frozen. Drain is its only consumer; the task thread's Step 1
+            // snapshot only reads entries, never mutates them. Putting peek inside the lock would
+            // add no safety and increase Step 1 contention.
+            while ((e = seg.peekNextEntry()) != null) {
+                RecoverableInputChannel ch = channelByInfo.get(e.channelInfo);
+                if (ch == null) {
+                    throw new IllegalStateException(
+                            "Drain: no physical channel found for " + e.channelInfo);
+                }
+
+                // (A) Buffer allocation outside the lock — parks on BufferManager.bufferQueue,
+                //     which must not happen while holding the checkpoint-trigger lock.
+                Buffer buf = bufferRequester.requestBufferBlocking(e.channelInfo);
+
+                // (B) Disk read outside the lock — buf is local to this iteration and not yet
+                //     visible to any other thread.
+                byte[] data = new byte[e.length];
+                seg.readBytesAt(e.offset, e.length, data);
+                buf.getMemorySegment().put(buf.getMemorySegmentOffset(), data, 0, e.length);
+                buf.setSize(e.length);
+
+                // (C) Critical section — deliver + advance offset must be a single atomic action
+                //     so the task-thread snapshot never observes a half-applied entry.
+                synchronized (lock) {
+                    ch.onRecoveredStateBuffer(buf);
+                    seg.pollNextEntry();
+                    currentSegmentIndex = seg.segmentIndex;
+                    currentOffset = e.offset + e.length;
+                }
+            }
+        }
+        // (D) End-of-drain: signal producer completion to every channel. The flag is published
+        //     through the channel's internal monitor that finishReadRecoveredState already takes.
+        for (RecoverableInputChannel ch : allChannels) {
+            ch.finishReadRecoveredState();
+        }
+    }
+
+    @Override
+    public DiskSnapshot snapshotAndInsertBarriers(long checkpointId) {
+        SpillFile.Snapshot diskSnap;
+        int startSegmentIndex;
+        long startOffset;
+
+        synchronized (lock) {
+            diskSnap = spillFile.snapshot();
+            startSegmentIndex = currentSegmentIndex;
+            startOffset = currentOffset;
+
+            // Recovery already done: every entry in the snapshot has been drained
+            // (lexicographic (segmentIndex, offset) < (currentSegmentIndex, currentOffset)).
+            // No barrier needs inserting; readers see an empty disk slice.
+            if (recoveryAlreadyDone(diskSnap, startSegmentIndex, startOffset)) {
+                return DiskSnapshot.empty();
+            }
+
+            for (RecoverableInputChannel ch : allChannels) {
+                ch.onRecoveredStateBuffer(new RecoveryCheckpointBarrier(checkpointId));
+            }
+        }
+
+        return new DiskSnapshot(
+                diskSnap, new DiskSnapshot.StartPos(startSegmentIndex, startOffset));
+    }
+
+    /**
+     * Releases the source channels' exclusive buffer pools, then closes the spill file. Phase 5
+     * will replace the direct close with a release through the ref-counter shared with the
+     * per-checkpoint readers.
+     */
+    @Override
+    public void close() throws IOException {
+        try {
+            bufferRequester.releaseExclusiveBuffers();
+        } finally {
+            spillFile.close();
+        }
+    }
+
+    /**
+     * True when every entry in {@code snap} has already been drained. Compared as the lexicographic
+     * two-tuple {@code (segmentIndex, offset)}; an entry with index < cursor is fully drained, one
+     * with index == cursor is drained only if its offset is strictly below the cursor offset (the
+     * offset cursor sits one byte past the last delivered entry).
+     */
+    private static boolean recoveryAlreadyDone(
+            SpillFile.Snapshot snap, int curSegment, long curOffset) {
+        for (SpillFile.Entry e : snap.getEntries()) {
+            boolean drained =
+                    e.segmentIndex < curSegment
+                            || (e.segmentIndex == curSegment && e.offset < curOffset);
+            if (!drained) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReader.java
@@ -80,6 +80,8 @@ public final class SpillFileReader implements RecoveryCheckpointTrigger, Closeab
         this.allChannels = checkNotNull(allChannels);
         this.channelByInfo = new HashMap<>(checkNotNull(channelByInfo));
         this.bufferRequester = checkNotNull(bufferRequester);
+        // Drain holds one ref-count grant for the lifetime of this reader; matched by close().
+        spillFile.acquire();
     }
 
     /**
@@ -145,31 +147,36 @@ public final class SpillFileReader implements RecoveryCheckpointTrigger, Closeab
 
             // Recovery already done: every entry in the snapshot has been drained
             // (lexicographic (segmentIndex, offset) < (currentSegmentIndex, currentOffset)).
-            // No barrier needs inserting; readers see an empty disk slice.
+            // No barrier needs inserting; readers see an empty disk slice and we MUST NOT take
+            // a ref-count grant — the empty singleton's close() is a no-op.
             if (recoveryAlreadyDone(diskSnap, startSegmentIndex, startOffset)) {
                 return DiskSnapshot.empty();
             }
 
+            // Pair this acquire with DiskSnapshot.close() — the writer-completion callback
+            // attached by the dispatcher (success path) and the abort path both close the
+            // snapshot, releasing the grant exactly once.
+            spillFile.acquire();
             for (RecoverableInputChannel ch : allChannels) {
                 ch.onRecoveredStateBuffer(new RecoveryCheckpointBarrier(checkpointId));
             }
         }
 
         return new DiskSnapshot(
-                diskSnap, new DiskSnapshot.StartPos(startSegmentIndex, startOffset));
+                diskSnap, new DiskSnapshot.StartPos(startSegmentIndex, startOffset), spillFile);
     }
 
     /**
-     * Releases the source channels' exclusive buffer pools, then closes the spill file. Phase 5
-     * will replace the direct close with a release through the ref-counter shared with the
-     * per-checkpoint readers.
+     * Releases the source channels' exclusive buffer pools, then releases the drain's ref-count
+     * grant on the spill file. Actual segment deletion happens inside {@link SpillFile#release()}
+     * only once both this grant and every {@link DiskSnapshot} grant have been released.
      */
     @Override
     public void close() throws IOException {
         try {
             bufferRequester.releaseExclusiveBuffers();
         } finally {
-            spillFile.close();
+            spillFile.release();
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReaderBootstrap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReaderBootstrap.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoverableInputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredInputChannel;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Helpers that wire a {@link SpillFileReader} onto the existing {@code channelIOExecutor} once
+ * conversion has run on the task thread. Keeps the channel-collection and reader construction
+ * details out of the task class itself.
+ */
+@Internal
+public final class SpillFileReaderBootstrap {
+
+    private SpillFileReaderBootstrap() {}
+
+    /**
+     * Collects all {@link RecoveredInputChannel}s currently attached to the given input gates,
+     * keyed by {@link InputChannelInfo}. Returns an insertion-ordered map. Called by the task
+     * thread before {@code requestPartitions()} converts the recovered channels to their physical
+     * forms — the resulting map is the source-channel set for {@link
+     * RecoveredChannelBufferRequester}.
+     */
+    public static Map<InputChannelInfo, RecoveredInputChannel> collectRecoveredChannels(
+            InputGate[] inputGates) {
+        Map<InputChannelInfo, RecoveredInputChannel> map = new LinkedHashMap<>();
+        for (InputGate gate : inputGates) {
+            int n = gate.getNumberOfInputChannels();
+            for (int i = 0; i < n; i++) {
+                InputChannel ch = gate.getChannel(i);
+                if (ch instanceof RecoveredInputChannel) {
+                    map.put(ch.getChannelInfo(), (RecoveredInputChannel) ch);
+                }
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Collects all physical {@link RecoverableInputChannel}s currently attached to the given input
+     * gates. Called by the task thread after {@code requestPartitions()} has run conversion, at
+     * which point every channel implements the recoverable interface (the physical Local/Remote
+     * channels) and the buffers delivered by the drain land in their queues.
+     */
+    public static List<RecoverableInputChannel> collectPhysicalChannels(InputGate[] inputGates) {
+        java.util.ArrayList<RecoverableInputChannel> list = new java.util.ArrayList<>();
+        for (InputGate gate : inputGates) {
+            int n = gate.getNumberOfInputChannels();
+            for (int i = 0; i < n; i++) {
+                InputChannel ch = gate.getChannel(i);
+                if (ch instanceof RecoverableInputChannel) {
+                    list.add((RecoverableInputChannel) ch);
+                }
+            }
+        }
+        return list;
+    }
+
+    /**
+     * Constructs a {@link SpillFileReader} from a frozen {@link SpillFile} and the
+     * before/after-conversion channel sets. Used by the task thread after conversion.
+     */
+    public static SpillFileReader buildReader(
+            SpillFile spillFile,
+            Map<InputChannelInfo, RecoveredInputChannel> sourceChannels,
+            List<RecoverableInputChannel> physicalChannels) {
+        Map<InputChannelInfo, RecoverableInputChannel> byInfo = new LinkedHashMap<>();
+        for (RecoverableInputChannel ch : physicalChannels) {
+            byInfo.put(((InputChannel) ch).getChannelInfo(), ch);
+        }
+        return new SpillFileReader(
+                spillFile,
+                physicalChannels,
+                byInfo,
+                new RecoveredChannelBufferRequester(new HashMap<>(sourceChannels)));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReaderBootstrap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReaderBootstrap.java
@@ -82,20 +82,16 @@ public final class SpillFileReaderBootstrap {
 
     /**
      * Constructs a {@link SpillFileReader} from a frozen {@link SpillFile} and the
-     * before/after-conversion channel sets. Used by the task thread after conversion.
+     * before/after-conversion channel sets. Used by the task thread after conversion. The {@code
+     * InputChannelInfo}-keyed map is derived internally from {@code physicalChannels}.
      */
     public static SpillFileReader buildReader(
             SpillFile spillFile,
             Map<InputChannelInfo, RecoveredInputChannel> sourceChannels,
             List<RecoverableInputChannel> physicalChannels) {
-        Map<InputChannelInfo, RecoverableInputChannel> byInfo = new LinkedHashMap<>();
-        for (RecoverableInputChannel ch : physicalChannels) {
-            byInfo.put(((InputChannel) ch).getChannelInfo(), ch);
-        }
         return new SpillFileReader(
                 spillFile,
                 physicalChannels,
-                byInfo,
                 new RecoveredChannelBufferRequester(new HashMap<>(sourceChannels)));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileWriter.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Filter-phase facade that pairs the {@link SpillFile} lifecycle with the {@link
+ * FilteredBufferWriter} accumulator. Callers in the filter phase see exactly one entry point
+ * ({@link #write}) and one teardown point ({@link #close}); the drain phase obtains the frozen
+ * {@link SpillFile} via {@link #getSpillFile} after close has been called.
+ */
+@Internal
+public final class SpillFileWriter implements Closeable {
+
+    private final SpillFile spillFile;
+    private final FilteredBufferWriter accumulator;
+    private boolean closed = false;
+
+    public SpillFileWriter(SpillFile spillFile, FilteredBufferWriter accumulator) {
+        this.spillFile = checkNotNull(spillFile);
+        this.accumulator = checkNotNull(accumulator);
+    }
+
+    /** Returns the underlying {@link SpillFile} so Phase 4 drain can read it post-close. */
+    public SpillFile getSpillFile() {
+        return spillFile;
+    }
+
+    /**
+     * Package-private access to the underlying accumulator. The filter-phase wiring in {@code
+     * RecoveredChannelStateHandler} needs the accumulator's stable pre-filter buffer to supply the
+     * filter's output allocator.
+     */
+    FilteredBufferWriter getAccumulator() {
+        return accumulator;
+    }
+
+    /**
+     * Delegates a filtered-output record to the accumulator. The caller retains buffer ownership;
+     * the accumulator copies the readable bytes.
+     */
+    public void write(InputChannelInfo channelInfo, Buffer buf)
+            throws IOException, InterruptedException {
+        accumulator.write(channelInfo, buf);
+    }
+
+    /**
+     * Closes the accumulator first (flushing residual bytes and itself closing the spill file),
+     * then defensively closes the spill file again. The second call is a no-op because {@link
+     * SpillFile#close} is idempotent, but it leaves the close-ordering invariant intentional and
+     * explicit in the facade.
+     */
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        try {
+            accumulator.close();
+        } finally {
+            spillFile.close();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SpillFileWriter.java
@@ -43,7 +43,7 @@ public final class SpillFileWriter implements Closeable {
         this.accumulator = checkNotNull(accumulator);
     }
 
-    /** Returns the underlying {@link SpillFile} so Phase 4 drain can read it post-close. */
+    /** Returns the underlying {@link SpillFile} so the drain can read it post-close. */
     public SpillFile getSpillFile() {
         return spillFile;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.TaskEventPublisher;
@@ -38,6 +39,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+import org.apache.flink.util.CloseableIterator;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,17 +49,21 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** An input channel, which requests a local subpartition. */
-public class LocalInputChannel extends InputChannel implements BufferAvailabilityListener {
+public class LocalInputChannel extends InputChannel
+        implements BufferAvailabilityListener, RecoverableInputChannel {
 
     private static final Logger LOG = LoggerFactory.getLogger(LocalInputChannel.class);
 
@@ -78,19 +84,49 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
     private final ChannelStatePersister channelStatePersister;
 
+    private final ChannelStateWriter channelStateWriter;
+
     private final Deque<BufferAndBacklog> toBeConsumedBuffers = new ArrayDeque<>();
 
     /**
-     * Buffers migrated from {@code RecoveredInputChannel}, kept separately from {@link
-     * #toBeConsumedBuffers} so that recovery semantics (priority event interleaving, checkpoint
-     * inflight persistence) do not leak into the FullyFilledBuffer split path.
+     * Buffers delivered by the drain phase during recovery. Guarded by {@code
+     * synchronized(recoveredBuffers)}.
      */
-    private final Deque<BufferAndBacklog> recoveredBuffers = new ArrayDeque<>();
+    private final Deque<Buffer> recoveredBuffers = new ArrayDeque<>();
+
+    /**
+     * True once the spill/drain producer has finished adding all recovered buffers into this
+     * channel. Guarded by {@code synchronized(recoveredBuffers)}. Initialized to {@code false}
+     * because every {@code LocalInputChannel} instance is expected to receive a closing {@link
+     * #finishReadRecoveredState()} call before it is exposed to consumers, regardless of whether
+     * any buffers were actually pushed (see {@code RecoveredInputChannel.toInputChannel()} and
+     * {@code UnknownInputChannel.toLocalInputChannel()}).
+     *
+     * <p>Full recovery completion is {@code allRecoveredBuffersDelivered == true &&
+     * recoveredBuffers.isEmpty()}.
+     */
+    private boolean allRecoveredBuffersDelivered = false;
+
+    /**
+     * Completes when both {@code allRecoveredBuffersDelivered} is true and {@code recoveredBuffers}
+     * is empty. The two trigger sites are {@link #finishReadRecoveredState()} (if the queue is
+     * already drained) and {@link #getNextBuffer()} (when it polls the last entry after the flag is
+     * set).
+     */
+    private final CompletableFuture<Void> stateConsumedFuture = new CompletableFuture<>();
+
+    /**
+     * Sequence number counter for buffers emitted during recovery. Starts at {@link
+     * Integer#MIN_VALUE} for no collision with live upstream sequence numbers. Single-threaded
+     * (task thread only).
+     */
+    private int recoverySequenceNumber = Integer.MIN_VALUE;
 
     /**
      * Flag indicating whether there is a pending priority event (e.g., checkpoint barrier) in the
-     * subpartitionView that should be consumed before recoveredBuffers. This is set by {@link
-     * #notifyPriorityEvent} and checked in {@link #getNextBuffer()}.
+     * subpartitionView that should be consumed before recoveredBuffers. Set by {@link
+     * #notifyPriorityEvent} and reset inside {@link #pullPriorityFromSubpartitionView()}. Volatile
+     * because it is written by the network thread and read by the task thread.
      */
     private volatile boolean hasPendingPriorityEvent = false;
 
@@ -105,8 +141,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
             int maxBackoff,
             Counter numBytesIn,
             Counter numBuffersIn,
-            ChannelStateWriter stateWriter,
-            ArrayDeque<Buffer> initialRecoveredBuffers) {
+            ChannelStateWriter stateWriter) {
 
         super(
                 inputGate,
@@ -120,31 +155,56 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
         this.partitionManager = checkNotNull(partitionManager);
         this.taskEventPublisher = checkNotNull(taskEventPublisher);
+        this.channelStateWriter = checkNotNull(stateWriter);
         this.channelStatePersister = new ChannelStatePersister(stateWriter, getChannelInfo());
+    }
 
-        // Migrate recovered buffers from RecoveredInputChannel if provided.
-        // These buffers have been filtered but not yet consumed by the Task.
-        if (!initialRecoveredBuffers.isEmpty()) {
-            final int expectedCount = initialRecoveredBuffers.size();
-            // Sequence number starts at Integer.MIN_VALUE, consistent with RecoveredInputChannel.
-            int seqNum = Integer.MIN_VALUE;
-            while (!initialRecoveredBuffers.isEmpty()) {
-                Buffer buffer = initialRecoveredBuffers.poll();
-                // Determine next data type based on the next buffer in the queue
-                Buffer.DataType nextDataType =
-                        initialRecoveredBuffers.isEmpty()
-                                ? Buffer.DataType.NONE
-                                : initialRecoveredBuffers.peek().getDataType();
-                // buffersInBacklog is set to 0 as these are recovered buffers
-                BufferAndBacklog bufferAndBacklog =
-                        new BufferAndBacklog(buffer, 0, nextDataType, seqNum++);
-                recoveredBuffers.add(bufferAndBacklog);
+    // ------------------------------------------------------------------------
+    // RecoverableInputChannel implementation
+    // ------------------------------------------------------------------------
+
+    /**
+     * Appends {@code buffer} to {@code recoveredBuffers}. If the channel has been released, the
+     * buffer is recycled silently. Wakes the consumer when the queue transitions from empty to
+     * non-empty.
+     *
+     * <p>Caller (drain thread or task thread at Step 1) MUST hold {@code SpillFileReader.lock}. The
+     * migration path in {@code RecoveredInputChannel.toInputChannel()} is an exception: it delivers
+     * buffers single-threaded before the channel is exposed to any other thread, so no {@code
+     * SpillFileReader.lock} exists at that point.
+     */
+    @Override
+    public void onRecoveredStateBuffer(Buffer buffer) {
+        boolean wasEmpty;
+        synchronized (recoveredBuffers) {
+            if (isReleased) {
+                buffer.recycleBuffer();
+                return;
             }
-            checkState(
-                    recoveredBuffers.size() == expectedCount,
-                    "Buffer migration failed: expected %s buffers but got %s",
-                    expectedCount,
-                    recoveredBuffers.size());
+            wasEmpty = recoveredBuffers.isEmpty();
+            recoveredBuffers.add(buffer);
+        }
+        if (wasEmpty) {
+            notifyChannelNonEmpty();
+        }
+    }
+
+    /**
+     * Flips {@code allRecoveredBuffersDelivered} to true exactly once and completes {@code
+     * stateConsumedFuture} immediately if {@code recoveredBuffers} is already empty.
+     *
+     * <p>End-of-drain exception: caller does NOT need to hold {@code SpillFileReader.lock} because
+     * no more buffers are being added at this point.
+     */
+    @Override
+    public void finishReadRecoveredState() throws IOException {
+        boolean shouldComplete;
+        synchronized (recoveredBuffers) {
+            allRecoveredBuffersDelivered = true;
+            shouldComplete = recoveredBuffers.isEmpty();
+        }
+        if (shouldComplete) {
+            stateConsumedFuture.complete(null);
         }
     }
 
@@ -152,17 +212,47 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     // Consume
     // ------------------------------------------------------------------------
 
+    @Override
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
-        // Collect inflight buffers from recoveredBuffers to be persisted.
-        // These are recovered buffers that have not been consumed yet when the checkpoint
-        // barrier arrives.
-        List<Buffer> inflightBuffers = new ArrayList<>();
-        for (BufferAndBacklog bufferAndBacklog : recoveredBuffers) {
-            if (bufferAndBacklog.buffer().isBuffer()) {
-                inflightBuffers.add(bufferAndBacklog.buffer().retainBuffer());
+        synchronized (recoveredBuffers) {
+            boolean inRecovery = !allRecoveredBuffersDelivered || !recoveredBuffers.isEmpty();
+            if (inRecovery) {
+                // Local has no receivedBuffers field; upstream live data arrives via
+                // subpartitionView only after recoveredBuffers is empty per getNextBuffer()
+                // invariant, so this assert is always trivially true.
+                assert receivedBuffersHasNoLiveDataBuffer();
+
+                List<Buffer> retained = new ArrayList<>();
+                Iterator<Buffer> it = recoveredBuffers.iterator();
+                while (it.hasNext()) {
+                    Buffer b = it.next();
+                    if (b instanceof RecoveryCheckpointBarrier
+                            && ((RecoveryCheckpointBarrier) b).getCheckpointId()
+                                    == barrier.getId()) {
+                        it.remove();
+                        break;
+                    }
+                    retained.add(b.retainBuffer());
+                }
+                channelStateWriter.addInputData(
+                        barrier.getId(),
+                        channelInfo,
+                        ChannelStateWriter.SEQUENCE_NUMBER_RESTORED,
+                        CloseableIterator.fromList(retained, Buffer::recycleBuffer));
+            } else {
+                // Not in recovery: master existing path.
+                channelStatePersister.startPersisting(barrier.getId(), Collections.emptyList());
             }
         }
-        channelStatePersister.startPersisting(barrier.getId(), inflightBuffers);
+    }
+
+    /**
+     * Returns true: Local has no {@code receivedBuffers}; upstream live data arrives only via
+     * {@code subpartitionView}, which is gated behind the {@code inRecovery} predicate in {@code
+     * getNextBuffer()}.
+     */
+    private boolean receivedBuffersHasNoLiveDataBuffer() {
+        return true;
     }
 
     public void checkpointStopped(long checkpointId) {
@@ -282,10 +372,33 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
         checkError();
 
-        if (!recoveredBuffers.isEmpty()) {
-            return getNextRecoveredBuffer();
+        boolean inRecovery;
+        synchronized (recoveredBuffers) {
+            inRecovery = !allRecoveredBuffersDelivered || !recoveredBuffers.isEmpty();
         }
 
+        if (inRecovery) {
+            if (hasPendingPriorityEvent) {
+                return pullPriorityFromSubpartitionView();
+            }
+            Buffer buf;
+            boolean drainedLast;
+            synchronized (recoveredBuffers) {
+                if (recoveredBuffers.isEmpty()) {
+                    // Queue is empty but flag is not yet set: drain not finished, block normal
+                    // upstream data until delivery completes.
+                    return Optional.empty();
+                }
+                buf = recoveredBuffers.poll();
+                drainedLast = recoveredBuffers.isEmpty() && allRecoveredBuffersDelivered;
+            }
+            if (drainedLast) {
+                stateConsumedFuture.complete(null);
+            }
+            return wrapRecoveredBufferAsAvailability(buf);
+        }
+
+        // Not in recovery: master existing path (FullyFilledBuffer splits → subpartitionView).
         if (!toBeConsumedBuffers.isEmpty()) {
             return getBufferAndAvailability(toBeConsumedBuffers.removeFirst());
         }
@@ -350,65 +463,94 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     }
 
     /**
-     * Consumes the next buffer from recoveredBuffers, handling pending priority events and dynamic
-     * availability detection for the last recovered buffer.
+     * Pulls the pending priority event from {@code subpartitionView}, resets {@code
+     * hasPendingPriorityEvent} if no further priority events follow, and corrects {@code
+     * nextDataType} to the head of {@code recoveredBuffers} when appropriate.
      */
-    private Optional<BufferAndAvailability> getNextRecoveredBuffer() throws IOException {
-        // If there is a pending priority event (e.g., unaligned checkpoint barrier), fetch it
-        // from subpartitionView first, skipping recoveredBuffers. This ensures priority
-        // events are processed immediately even when there are pending recovered buffers.
-        if (hasPendingPriorityEvent) {
-            checkState(subpartitionView != null, "No subpartition view available");
-            BufferAndBacklog next = subpartitionView.getNextBuffer();
-            checkState(
-                    next != null && next.buffer().getDataType().hasPriority(),
-                    "Expected priority event, but got %s",
-                    next == null ? "null" : next.buffer().getDataType());
+    private Optional<BufferAndAvailability> pullPriorityFromSubpartitionView() throws IOException {
+        checkState(subpartitionView != null, "No subpartition view available");
+        BufferAndBacklog next = subpartitionView.getNextBuffer();
+        checkState(
+                next != null && next.buffer().getDataType().hasPriority(),
+                "Expected priority event, but got %s",
+                next == null ? "null" : next.buffer().getDataType());
 
-            // Check for barrier to update channel state persister.
-            // Note: maybePersist is not needed for barriers as they are not regular data buffers.
-            channelStatePersister.checkForBarrier(next.buffer());
+        channelStatePersister.checkForBarrier(next.buffer());
 
-            Buffer.DataType expectedNextDataType = next.getNextDataType();
-            if (!expectedNextDataType.hasPriority()) {
-                // Reset hasPendingPriorityEvent to false if no more priority event
-                hasPendingPriorityEvent = false;
+        Buffer.DataType expectedNextDataType = next.getNextDataType();
+        if (!expectedNextDataType.hasPriority()) {
+            // No more priority events; reset so next call goes through the recovery queue.
+            hasPendingPriorityEvent = false;
+            synchronized (recoveredBuffers) {
                 if (!recoveredBuffers.isEmpty()) {
-                    // Correct nextDataType: if recoveredBuffers is not empty, the actual next
-                    // element to consume is from recoveredBuffers, not from subpartitionView
-                    expectedNextDataType = recoveredBuffers.peek().buffer().getDataType();
+                    // Correct nextDataType: the actual next element to consume is the head of
+                    // recoveredBuffers, not whatever subpartitionView reports.
+                    expectedNextDataType = recoveredBuffers.peek().getDataType();
                 }
             }
-
-            return getBufferAndAvailability(
-                    new BufferAndBacklog(
-                            next.buffer(),
-                            next.buffersInBacklog(),
-                            expectedNextDataType,
-                            next.getSequenceNumber()));
         }
 
-        BufferAndBacklog next = recoveredBuffers.removeFirst();
+        return Optional.of(
+                new BufferAndAvailability(
+                        next.buffer(),
+                        expectedNextDataType,
+                        next.buffersInBacklog(),
+                        next.getSequenceNumber()));
+    }
 
-        // If this is the last recovered buffer and nextDataType is NONE,
-        // dynamically check if subpartitionView has data available.
-        // The last buffer's nextDataType was preset to NONE during construction,
-        // but subpartitionView may already have data available.
-        if (recoveredBuffers.isEmpty()
-                && next.getNextDataType() == Buffer.DataType.NONE
-                && subpartitionView != null) {
-            ResultSubpartitionView.AvailabilityWithBacklog availability =
-                    subpartitionView.getAvailabilityAndBacklog(true);
-            if (availability.isAvailable()) {
-                next =
-                        new BufferAndBacklog(
-                                next.buffer(),
-                                availability.getBacklog(),
-                                Buffer.DataType.DATA_BUFFER,
-                                next.getSequenceNumber());
+    /**
+     * Wraps a raw {@code Buffer} polled from {@code recoveredBuffers} into a {@link
+     * BufferAndAvailability}. Computes {@code nextDataType} based on the current queue state:
+     *
+     * <ul>
+     *   <li>Queue non-empty: peek at the head.
+     *   <li>Queue empty, flag not yet true: NONE (drain will push more).
+     *   <li>Queue empty and flag true: probe {@code subpartitionView} for the actual next type.
+     * </ul>
+     */
+    private Optional<BufferAndAvailability> wrapRecoveredBufferAsAvailability(Buffer buf)
+            throws IOException {
+        if (buf instanceof FileRegionBuffer) {
+            buf = ((FileRegionBuffer) buf).readInto(inputGate.getUnpooledSegment());
+        }
+        if (buf instanceof CompositeBuffer) {
+            buf = ((CompositeBuffer) buf).getFullBufferData(inputGate.getUnpooledSegment());
+        }
+
+        numBytesIn.inc(buf.readableBytes());
+        numBuffersIn.inc();
+
+        Buffer.DataType nextDataType;
+        synchronized (recoveredBuffers) {
+            if (!recoveredBuffers.isEmpty()) {
+                nextDataType = recoveredBuffers.peek().getDataType();
+            } else if (!allRecoveredBuffersDelivered) {
+                nextDataType = Buffer.DataType.NONE;
+            } else {
+                // Last recovered buffer consumed; probe subpartitionView for what comes next.
+                ResultSubpartitionView view = subpartitionView;
+                if (view != null) {
+                    ResultSubpartitionView.AvailabilityWithBacklog availability =
+                            view.getAvailabilityAndBacklog(true);
+                    nextDataType =
+                            availability.isAvailable()
+                                    ? Buffer.DataType.DATA_BUFFER
+                                    : Buffer.DataType.NONE;
+                } else {
+                    nextDataType = Buffer.DataType.NONE;
+                }
             }
         }
-        return getBufferAndAvailability(next);
+
+        NetworkActionsLogger.traceInput(
+                "LocalInputChannel#getNextBuffer",
+                buf,
+                inputGate.getOwningTaskName(),
+                channelInfo,
+                channelStatePersister,
+                recoverySequenceNumber);
+        return Optional.of(
+                new BufferAndAvailability(buf, nextDataType, 0, recoverySequenceNumber++));
     }
 
     private Optional<BufferAndAvailability> getBufferAndAvailability(BufferAndBacklog next)
@@ -449,7 +591,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     @Override
     public void notifyPriorityEvent(int prioritySequenceNumber) {
         // Set flag so that getNextBuffer() knows to fetch priority event from subpartitionView
-        // before consuming toBeConsumedBuffers.
+        // before consuming recoveredBuffers.
         hasPendingPriorityEvent = true;
         super.notifyPriorityEvent(prioritySequenceNumber);
     }
@@ -526,13 +668,13 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                 subpartitionView = null;
             }
 
-            // Release any remaining buffers in recoveredBuffers (migrated recovered buffers
-            // not yet consumed) and toBeConsumedBuffers (FullyFilledBuffer partial splits)
-            // to avoid memory leak.
-            for (BufferAndBacklog bufferAndBacklog : recoveredBuffers) {
-                bufferAndBacklog.buffer().recycleBuffer();
+            // Release any remaining buffers in recoveredBuffers and toBeConsumedBuffers.
+            synchronized (recoveredBuffers) {
+                for (Buffer buffer : recoveredBuffers) {
+                    buffer.recycleBuffer();
+                }
+                recoveredBuffers.clear();
             }
-            recoveredBuffers.clear();
             for (BufferAndBacklog bufferAndBacklog : toBeConsumedBuffers) {
                 bufferAndBacklog.buffer().recycleBuffer();
             }
@@ -589,5 +731,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     @VisibleForTesting
     ResultSubpartitionView getSubpartitionView() {
         return subpartitionView;
+    }
+
+    @VisibleForTesting
+    CompletableFuture<Void> getStateConsumedFuture() {
+        return stateConsumedFuture;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalRecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalRecoveredInputChannel.java
@@ -19,13 +19,10 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.runtime.io.network.TaskEventPublisher;
-import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
-
-import java.util.ArrayDeque;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -64,7 +61,7 @@ public class LocalRecoveredInputChannel extends RecoveredInputChannel {
     }
 
     @Override
-    protected InputChannel toInputChannelInternal(ArrayDeque<Buffer> remainingBuffers) {
+    protected InputChannel toInputChannelInternal() {
         return new LocalInputChannel(
                 inputGate,
                 getChannelIndex(),
@@ -76,7 +73,6 @@ public class LocalRecoveredInputChannel extends RecoveredInputChannel {
                 maxBackoff,
                 numBytesIn,
                 numBuffersIn,
-                channelStateWriter,
-                remainingBuffers);
+                channelStateWriter);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoverableInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoverableInputChannel.java
@@ -52,10 +52,9 @@ public interface RecoverableInputChannel {
      * queued in {@code recoveredBuffers}. The channel completes {@code stateConsumedFuture} once
      * both this flag is {@code true} AND {@code recoveredBuffers} is empty.
      *
-     * <p>End-of-drain exception: caller does NOT need to hold {@code SpillFileReader.lock}.
-     * At this point no more buffers are being added, so the (queue, offset) atomicity that
-     * Principle 1 protects does not apply. The flag is published through the channel's own internal
-     * monitor.
+     * <p>End-of-drain exception: caller does NOT need to hold {@code SpillFileReader.lock}. At this
+     * point no more buffers are being added, so the (queue, offset) atomicity that Principle 1
+     * protects does not apply. The flag is published through the channel's own internal monitor.
      *
      * @throws IOException if an error occurs while finalising the channel state
      */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoverableInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoverableInputChannel.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import java.io.IOException;
+
+/**
+ * Implemented by {@code RecoveredInputChannel}, {@code LocalInputChannel}, and {@code
+ * RemoteInputChannel}. The drain (SpillFileReader) holds channel references typed as this interface
+ * and never casts down; method names mirror the existing {@code RecoveredInputChannel} API.
+ */
+@Internal
+public interface RecoverableInputChannel {
+
+    /**
+     * Appends a recovered buffer (or a {@code RecoveryCheckpointBarrier} sentinel) to this
+     * channel's {@code recoveredBuffers} queue. If the channel has already been released, the
+     * buffer is recycled silently. Wakes the consumer via the existing {@code
+     * notifyChannelNonEmpty} chain if the queue was empty before this call.
+     *
+     * <p>Caller (drain thread or task thread at Step 1) MUST hold {@code SpillFileReader.lock}.
+     * This ensures that advancing {@code SpillFileReader}'s internal offset and the corresponding
+     * channel add-buffer are atomic, so neither side can observe an entry that belongs to both the
+     * memory snapshot and the disk snapshot simultaneously.
+     *
+     * @param buffer the recovered data buffer or the {@code RecoveryCheckpointBarrier} sentinel
+     */
+    void onRecoveredStateBuffer(Buffer buffer);
+
+    /**
+     * Signals that the spill/drain producer has finished adding recovered buffers into this
+     * channel. Flips {@code allRecoveredBuffersDelivered} from {@code false} to {@code true}
+     * exactly once (producer-side completion only). The consumer may still have leftover buffers
+     * queued in {@code recoveredBuffers}. The channel completes {@code stateConsumedFuture} once
+     * both this flag is {@code true} AND {@code recoveredBuffers} is empty.
+     *
+     * <p>End-of-drain exception: caller does NOT need to hold {@code SpillFileReader.lock}.
+     * At this point no more buffers are being added, so the (queue, offset) atomicity that
+     * Principle 1 protects does not apply. The flag is published through the channel's own internal
+     * monitor.
+     *
+     * @throws IOException if an error occurs while finalising the channel state
+     */
+    void finishReadRecoveredState() throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoverableInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoverableInputChannel.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 
 import java.io.IOException;
@@ -29,6 +30,14 @@ import java.io.IOException;
  */
 @Internal
 public interface RecoverableInputChannel {
+
+    /**
+     * Identifies the channel within its task. Every concrete implementor extends {@link
+     * InputChannel}, which exposes the same getter; surfacing it on the interface lets the drain
+     * (and any other consumer holding the interface type) build {@code InputChannelInfo}-keyed
+     * lookups without downcasting to {@link InputChannel}.
+     */
+    InputChannelInfo getChannelInfo();
 
     /**
      * Appends a recovered buffer (or a {@code RecoveryCheckpointBarrier} sentinel) to this

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -307,7 +307,7 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
         }
     }
 
-    void releaseAllResources() throws IOException {
+    public void releaseAllResources() throws IOException {
         ArrayDeque<Buffer> releasedBuffers = new ArrayDeque<>();
         boolean shouldRelease = false;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -19,8 +19,6 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
@@ -29,13 +27,10 @@ import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
-import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
-import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.ChannelStateHolder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
-import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -348,31 +343,13 @@ public abstract class RecoveredInputChannel extends InputChannel
     }
 
     public Buffer requestBufferBlocking() throws InterruptedException, IOException {
-        // not in setup to avoid assigning buffers unnecessarily if there is no state
+        // Lazy exclusive-buffer assignment — avoids reserving the pool for channels that have
+        // no recovered state to consume.
         if (!exclusiveBuffersAssigned) {
             bufferManager.requestExclusiveBuffers(networkBuffersPerChannel);
             exclusiveBuffersAssigned = true;
         }
-        if (!inputGate.isCheckpointingDuringRecoveryEnabled()) {
-            // When checkpoint-during-recovery is not enabled, the original blocking allocation
-            // is used as-is — no heap buffer fallback, no behavior change from the legacy path.
-            return bufferManager.requestBufferBlocking();
-        }
-        // Use heap buffer fallback to avoid deadlock during filtering recovery: the filtering
-        // thread first requests buffers to read state (pre-filter), then requests more buffers
-        // to write filtered output (post-filter). If pre-filter buffers exhaust the pool,
-        // post-filter allocation blocks, stalling the thread so pre-filter buffers can never
-        // be consumed and released — the thread deadlocks itself. Heap buffers bypass the pool
-        // so post-filter writes always proceed. Both call sites (getBuffer and filterAndRewrite)
-        // go through this method, so the fallback applies uniformly.
-        // TODO: replace heap fallback with disk spilling to bound memory usage in FLINK-38544.
-        Buffer buffer = bufferManager.requestBuffer();
-        if (buffer != null) {
-            return buffer;
-        }
-        MemorySegment memorySegment =
-                MemorySegmentFactory.allocateUnpooledSegment(MemoryManager.DEFAULT_PAGE_SIZE);
-        return new NetworkBuffer(memorySegment, FreeingBufferRecycler.INSTANCE);
+        return bufferManager.requestBufferBlocking();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -54,7 +54,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** An input channel reads recovered state from previous unaligned checkpoint snapshots. */
-public abstract class RecoveredInputChannel extends InputChannel implements ChannelStateHolder {
+public abstract class RecoveredInputChannel extends InputChannel
+        implements ChannelStateHolder, RecoverableInputChannel {
 
     private static final Logger LOG = LoggerFactory.getLogger(RecoveredInputChannel.class);
 
@@ -131,8 +132,23 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
             receivedBuffers.clear();
         }
 
-        final InputChannel inputChannel = toInputChannelInternal(remainingBuffers);
+        final InputChannel inputChannel = toInputChannelInternal();
         inputChannel.checkpointStopped(lastStoppedCheckpointId);
+
+        // Feed remaining buffers via the uniform push interface. This migration path has no
+        // SpillFileReader.lock (no spiller exists yet); delivery is single-threaded and sequential,
+        // occurring before the physical channel is exposed to any other thread.
+        if (inputChannel instanceof RecoverableInputChannel) {
+            RecoverableInputChannel rec = (RecoverableInputChannel) inputChannel;
+            for (Buffer buf : remainingBuffers) {
+                rec.onRecoveredStateBuffer(buf);
+            }
+            rec.finishReadRecoveredState();
+        } else {
+            throw new IllegalStateException(
+                    "Physical channel does not implement RecoverableInputChannel: "
+                            + inputChannel.getClass().getName());
+        }
         return inputChannel;
     }
 
@@ -142,14 +158,13 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     }
 
     /**
-     * Creates the physical InputChannel from this recovered channel.
+     * Creates the physical InputChannel from this recovered channel. The remaining buffers are
+     * delivered via {@link RecoverableInputChannel#onRecoveredStateBuffer} after this method
+     * returns.
      *
-     * @param remainingBuffers buffers that have been filtered but not yet consumed by the Task.
-     *     These buffers will be migrated to the new physical channel.
      * @return the physical InputChannel (LocalInputChannel or RemoteInputChannel)
      */
-    protected abstract InputChannel toInputChannelInternal(ArrayDeque<Buffer> remainingBuffers)
-            throws IOException;
+    protected abstract InputChannel toInputChannelInternal() throws IOException;
 
     /**
      * Returns the future that completes when buffer filtering is complete. This future completes

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -25,6 +25,7 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
@@ -45,6 +46,7 @@ import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.PrioritizedDeque;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
+import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.flink.shaded.guava33.com.google.common.collect.Iterators;
@@ -58,10 +60,12 @@ import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -72,7 +76,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** An input channel, which requests a remote partition queue. */
-public class RemoteInputChannel extends InputChannel {
+public class RemoteInputChannel extends InputChannel implements RecoverableInputChannel {
     private static final Logger LOG = LoggerFactory.getLogger(RemoteInputChannel.class);
 
     private static final int NONE = -1;
@@ -123,6 +127,44 @@ public class RemoteInputChannel extends InputChannel {
 
     private final ChannelStatePersister channelStatePersister;
 
+    private final ChannelStateWriter channelStateWriter;
+
+    /**
+     * Buffers delivered by the drain phase during recovery. Guarded by {@code
+     * synchronized(receivedBuffers)} (reusing the existing channel monitor).
+     */
+    @GuardedBy("receivedBuffers")
+    private final Deque<Buffer> recoveredBuffers = new ArrayDeque<>();
+
+    /**
+     * True once the spill/drain producer has finished adding all recovered buffers into this
+     * channel. Guarded by {@code synchronized(receivedBuffers)}. Initialized to {@code false}
+     * because every {@code RemoteInputChannel} instance is expected to receive a closing {@link
+     * #finishReadRecoveredState()} call before it is exposed to consumers, regardless of whether
+     * any buffers were actually pushed (see {@code RecoveredInputChannel.toInputChannel()} and
+     * {@code UnknownInputChannel.toRemoteInputChannel()}).
+     *
+     * <p>Full recovery completion is {@code allRecoveredBuffersDelivered == true &&
+     * recoveredBuffers.isEmpty()}.
+     */
+    @GuardedBy("receivedBuffers")
+    private boolean allRecoveredBuffersDelivered = false;
+
+    /**
+     * Completes when both {@code allRecoveredBuffersDelivered} is true and {@code recoveredBuffers}
+     * is empty. The two trigger sites are {@link #finishReadRecoveredState()} (if the queue is
+     * already drained) and {@link #getNextBuffer()} (when it polls the last entry after the flag is
+     * set).
+     */
+    private final CompletableFuture<Void> stateConsumedFuture = new CompletableFuture<>();
+
+    /**
+     * Sequence number counter for buffers emitted during recovery. Starts at {@link
+     * Integer#MIN_VALUE} for no collision with live upstream sequence numbers. Single-threaded
+     * (task thread only).
+     */
+    private int recoverySequenceNumber = Integer.MIN_VALUE;
+
     private long totalQueueSizeInBytes;
 
     public RemoteInputChannel(
@@ -138,8 +180,7 @@ public class RemoteInputChannel extends InputChannel {
             int networkBuffersPerChannel,
             Counter numBytesIn,
             Counter numBuffersIn,
-            ChannelStateWriter stateWriter,
-            ArrayDeque<Buffer> initialRecoveredBuffers) {
+            ChannelStateWriter stateWriter) {
 
         super(
                 inputGate,
@@ -157,30 +198,8 @@ public class RemoteInputChannel extends InputChannel {
         this.connectionId = checkNotNull(connectionId);
         this.connectionManager = checkNotNull(connectionManager);
         this.bufferManager = new BufferManager(inputGate.getMemorySegmentProvider(), this, 0);
+        this.channelStateWriter = checkNotNull(stateWriter);
         this.channelStatePersister = new ChannelStatePersister(stateWriter, getChannelInfo());
-
-        // Migrate recovered buffers from RecoveredInputChannel if provided.
-        // These buffers have been filtered but not yet consumed by the Task.
-        if (!initialRecoveredBuffers.isEmpty()) {
-            final int expectedCount = initialRecoveredBuffers.size();
-            // Sequence number starts at Integer.MIN_VALUE, consistent with RecoveredInputChannel.
-            int seqNum = Integer.MIN_VALUE;
-            for (Buffer buffer : initialRecoveredBuffers) {
-                // subpartitionId is set to 0 for recovered buffers. This is correct because:
-                // 1) For single-subpartition channels, the only valid subpartition is 0.
-                // 2) For multi-subpartition channels (consumedSubpartitionIndexSet.size() > 1),
-                //    RecoveryMetadata events embedded in the recovered buffer sequence track
-                //    the actual subpartition context for proper routing.
-                SequenceBuffer sequenceBuffer = new SequenceBuffer(buffer, seqNum++, 0);
-                receivedBuffers.add(sequenceBuffer);
-                totalQueueSizeInBytes += buffer.getSize();
-            }
-            checkState(
-                    receivedBuffers.size() == expectedCount,
-                    "Buffer migration failed: expected %s buffers but got %s",
-                    expectedCount,
-                    receivedBuffers.size());
-        }
     }
 
     @VisibleForTesting
@@ -199,6 +218,55 @@ public class RemoteInputChannel extends InputChannel {
                 "Bug in input channel setup logic: exclusive buffers have already been set for this input channel.");
 
         bufferManager.requestExclusiveBuffers(initialCredit);
+    }
+
+    // ------------------------------------------------------------------------
+    // RecoverableInputChannel implementation
+    // ------------------------------------------------------------------------
+
+    /**
+     * Appends {@code buffer} to {@code recoveredBuffers}. If the channel has been released, the
+     * buffer is recycled silently. Wakes the consumer when the queue transitions from empty to
+     * non-empty.
+     *
+     * <p>Caller (drain thread or task thread at Step 1) MUST hold {@code SpillFileReader.lock}. The
+     * migration path in {@code RecoveredInputChannel.toInputChannel()} is an exception: it delivers
+     * buffers single-threaded before the channel is exposed to any other thread, so no {@code
+     * SpillFileReader.lock} exists at that point.
+     */
+    @Override
+    public void onRecoveredStateBuffer(Buffer buffer) {
+        boolean wasEmpty;
+        synchronized (receivedBuffers) {
+            if (isReleased.get()) {
+                buffer.recycleBuffer();
+                return;
+            }
+            wasEmpty = recoveredBuffers.isEmpty();
+            recoveredBuffers.add(buffer);
+        }
+        if (wasEmpty) {
+            notifyChannelNonEmpty();
+        }
+    }
+
+    /**
+     * Flips {@code allRecoveredBuffersDelivered} to true exactly once and completes {@code
+     * stateConsumedFuture} immediately if {@code recoveredBuffers} is already empty.
+     *
+     * <p>End-of-drain exception: caller does NOT need to hold {@code SpillFileReader.lock} because
+     * no more buffers are being added at this point.
+     */
+    @Override
+    public void finishReadRecoveredState() throws IOException {
+        boolean shouldComplete;
+        synchronized (receivedBuffers) {
+            allRecoveredBuffersDelivered = true;
+            shouldComplete = recoveredBuffers.isEmpty();
+        }
+        if (shouldComplete) {
+            stateConsumedFuture.complete(null);
+        }
     }
 
     // ------------------------------------------------------------------------
@@ -278,6 +346,61 @@ public class RemoteInputChannel extends InputChannel {
 
     @Override
     public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
+        // Surface any error set on this channel (e.g. by onError, channel handler) before either
+        // the recovery or master branch — the master branch goes through checkReadability which
+        // also calls checkError, but the in-recovery branch otherwise has no error-surfacing path.
+        checkError();
+
+        boolean inRecovery;
+        synchronized (receivedBuffers) {
+            inRecovery = !allRecoveredBuffersDelivered || !recoveredBuffers.isEmpty();
+        }
+
+        if (inRecovery) {
+            // Priority events (e.g. UC barriers) may arrive in receivedBuffers with priority
+            // position during recovery; serve them first so checkpoints can fire while drain runs.
+            synchronized (receivedBuffers) {
+                if (receivedBuffers.getNumPriorityElements() > 0) {
+                    return pollReceivedBufferAsPriority();
+                }
+                if (recoveredBuffers.isEmpty()) {
+                    // Drain not finished yet; block normal upstream data.
+                    if (isReleased.get()) {
+                        throw new CancelTaskException(
+                                "Queried for a buffer after channel has been released.");
+                    }
+                    return Optional.empty();
+                }
+                Buffer buf = recoveredBuffers.poll();
+                boolean drainedLast = recoveredBuffers.isEmpty() && allRecoveredBuffersDelivered;
+                DataType nextDataType =
+                        !recoveredBuffers.isEmpty()
+                                ? recoveredBuffers.peek().getDataType()
+                                : (!allRecoveredBuffersDelivered
+                                        ? DataType.NONE
+                                        : (receivedBuffers.peek() != null
+                                                ? receivedBuffers.peek().buffer.getDataType()
+                                                : DataType.NONE));
+                // stateConsumedFuture.complete is idempotent; safe to call outside the lock as
+                // well, but doing it here keeps the unlock simpler.
+                if (drainedLast) {
+                    stateConsumedFuture.complete(null);
+                }
+                numBytesIn.inc(buf.getSize());
+                numBuffersIn.inc();
+                NetworkActionsLogger.traceInput(
+                        "RemoteInputChannel#getNextBuffer",
+                        buf,
+                        inputGate.getOwningTaskName(),
+                        channelInfo,
+                        channelStatePersister,
+                        recoverySequenceNumber);
+                return Optional.of(
+                        new BufferAndAvailability(buf, nextDataType, 0, recoverySequenceNumber++));
+            }
+        }
+
+        // Not in recovery: master existing path.
         final SequenceBuffer next;
         final DataType nextDataType;
 
@@ -312,6 +435,41 @@ public class RemoteInputChannel extends InputChannel {
                 next.sequenceNumber);
         numBytesIn.inc(next.buffer.getSize());
         numBuffersIn.inc();
+        return Optional.of(
+                new BufferAndAvailability(next.buffer, nextDataType, 0, next.sequenceNumber));
+    }
+
+    /** Polls the priority-position head from {@code receivedBuffers} during recovery. */
+    private Optional<BufferAndAvailability> pollReceivedBufferAsPriority() {
+        assert Thread.holdsLock(receivedBuffers);
+        SequenceBuffer next = receivedBuffers.poll();
+        if (next != null) {
+            totalQueueSizeInBytes -= next.buffer.getSize();
+        }
+        if (next == null) {
+            if (isReleased.get()) {
+                throw new CancelTaskException(
+                        "Queried for a buffer after channel has been released.");
+            }
+            return Optional.empty();
+        }
+        DataType nextDataType;
+        if (!recoveredBuffers.isEmpty()) {
+            nextDataType = recoveredBuffers.peek().getDataType();
+        } else if (receivedBuffers.peek() != null) {
+            nextDataType = receivedBuffers.peek().buffer.getDataType();
+        } else {
+            nextDataType = DataType.NONE;
+        }
+        numBytesIn.inc(next.buffer.getSize());
+        numBuffersIn.inc();
+        NetworkActionsLogger.traceInput(
+                "RemoteInputChannel#getNextBuffer",
+                next.buffer,
+                inputGate.getOwningTaskName(),
+                channelInfo,
+                channelStatePersister,
+                next.sequenceNumber);
         return Optional.of(
                 new BufferAndAvailability(next.buffer, nextDataType, 0, next.sequenceNumber));
     }
@@ -351,6 +509,11 @@ public class RemoteInputChannel extends InputChannel {
                                 .map(sb -> sb.buffer)
                                 .collect(Collectors.toCollection(ArrayDeque::new));
                 receivedBuffers.clear();
+                // Release any remaining recovered buffers that were not yet consumed.
+                for (Buffer buf : recoveredBuffers) {
+                    buf.recycleBuffer();
+                }
+                recoveredBuffers.clear();
             }
             bufferManager.releaseAllBuffers(releasedBuffers);
 
@@ -708,30 +871,73 @@ public class RemoteInputChannel extends InputChannel {
     }
 
     /**
-     * Spills all queued buffers on checkpoint start. If barrier has already been received (and
-     * reordered), spill only the overtaken buffers.
+     * Spills queued buffers on checkpoint start. In recovery, scans {@code recoveredBuffers} up to
+     * the {@code RecoveryCheckpointBarrier} sentinel matching the given checkpoint id and persists
+     * pre-barrier buffers. Outside recovery, follows the master existing path.
      */
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
         synchronized (receivedBuffers) {
-            if (barrier.getId() < lastBarrierId) {
-                throw new CheckpointException(
-                        String.format(
-                                "Sequence number for checkpoint %d is not known (it was likely been overwritten by a newer checkpoint %d)",
-                                barrier.getId(), lastBarrierId),
-                        CheckpointFailureReason
-                                .CHECKPOINT_SUBSUMED); // currently, at most one active unaligned
-                // checkpoint is possible
-            } else if (barrier.getId() > lastBarrierId) {
-                // This channel has received some obsolete barrier, older compared to the
-                // checkpointId
-                // which we are processing right now, and we should ignore that obsoleted checkpoint
-                // barrier sequence number.
-                resetLastBarrier();
-            }
+            boolean inRecovery = !allRecoveredBuffersDelivered || !recoveredBuffers.isEmpty();
+            if (inRecovery) {
+                // Defensive: during recovery, receivedBuffers must contain only priority/control
+                // buffers (no live data). This invariant is violated if upstream sent data while
+                // the channel was still draining recovered state.
+                assert receivedBuffersHasNoLiveDataBuffer()
+                        : "live upstream data observed in receivedBuffers during recovery";
 
-            channelStatePersister.startPersisting(
-                    barrier.getId(), getInflightBuffersUnsafe(barrier.getId()));
+                List<Buffer> retained = new ArrayList<>();
+                Iterator<Buffer> it = recoveredBuffers.iterator();
+                while (it.hasNext()) {
+                    Buffer b = it.next();
+                    if (b instanceof RecoveryCheckpointBarrier
+                            && ((RecoveryCheckpointBarrier) b).getCheckpointId()
+                                    == barrier.getId()) {
+                        it.remove();
+                        break;
+                    }
+                    retained.add(b.retainBuffer());
+                }
+                channelStateWriter.addInputData(
+                        barrier.getId(),
+                        channelInfo,
+                        ChannelStateWriter.SEQUENCE_NUMBER_RESTORED,
+                        CloseableIterator.fromList(retained, Buffer::recycleBuffer));
+            } else {
+                // Not in recovery: master existing path.
+                if (barrier.getId() < lastBarrierId) {
+                    throw new CheckpointException(
+                            String.format(
+                                    "Sequence number for checkpoint %d is not known (it was likely been overwritten by a newer checkpoint %d)",
+                                    barrier.getId(), lastBarrierId),
+                            CheckpointFailureReason.CHECKPOINT_SUBSUMED);
+                } else if (barrier.getId() > lastBarrierId) {
+                    resetLastBarrier();
+                }
+                channelStatePersister.startPersisting(
+                        barrier.getId(), getInflightBuffersUnsafe(barrier.getId()));
+            }
         }
+    }
+
+    /**
+     * Returns true if {@code receivedBuffers} contains no live data buffers (only priority/control
+     * buffers are allowed during recovery).
+     */
+    private boolean receivedBuffersHasNoLiveDataBuffer() {
+        assert Thread.holdsLock(receivedBuffers);
+        // Skip priority elements at the head; check all remaining elements.
+        Iterator<SequenceBuffer> it = receivedBuffers.iterator();
+        while (it.hasNext()) {
+            if (it.next().buffer.isBuffer()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @VisibleForTesting
+    CompletableFuture<Void> getStateConsumedFuture() {
+        return stateConsumedFuture;
     }
 
     public void checkpointStopped(long checkpointId) {
@@ -904,13 +1110,14 @@ public class RemoteInputChannel extends InputChannel {
     }
 
     /**
-     * When receivedBuffers contains migrated buffers from RecoveredInputChannel, they can be read
-     * before requestSubpartitions(). In that case only check for errors. Once migrated buffers are
-     * drained, require full client initialization check.
+     * When this channel is still in the recovery phase (recoveredBuffers non-empty or flag not yet
+     * set), it can be read before requestSubpartitions(). In that case only check for errors. Once
+     * recovery is done, require full client initialization check.
      */
     private void checkReadability() throws IOException {
         assert Thread.holdsLock(receivedBuffers);
-        if (receivedBuffers.isEmpty()) {
+        boolean inRecovery = !allRecoveredBuffersDelivered || !recoveredBuffers.isEmpty();
+        if (!inRecovery && receivedBuffers.isEmpty()) {
             checkPartitionRequestQueueInitialized();
         } else {
             checkError();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
@@ -20,13 +20,11 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
-import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -68,8 +66,7 @@ public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
     }
 
     @Override
-    protected InputChannel toInputChannelInternal(ArrayDeque<Buffer> remainingBuffers)
-            throws IOException {
+    protected InputChannel toInputChannelInternal() throws IOException {
         RemoteInputChannel remoteInputChannel =
                 new RemoteInputChannel(
                         inputGate,
@@ -84,8 +81,7 @@ public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
                         networkBuffersPerChannel,
                         numBytesIn,
                         numBuffersIn,
-                        channelStateWriter,
-                        remainingBuffers);
+                        channelStateWriter);
         remoteInputChannel.setup();
         return remoteInputChannel;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -35,7 +35,6 @@ import org.apache.flink.util.Preconditions;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.Optional;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_DECLINED_TASK_NOT_READY;
@@ -171,37 +170,56 @@ class UnknownInputChannel extends InputChannel implements ChannelStateHolder {
 
     public RemoteInputChannel toRemoteInputChannel(
             ConnectionID producerAddress, ResultPartitionID resultPartitionID) {
-        return new RemoteInputChannel(
-                inputGate,
-                getChannelIndex(),
-                resultPartitionID,
-                consumedSubpartitionIndexSet,
-                checkNotNull(producerAddress),
-                connectionManager,
-                initialBackoff,
-                maxBackoff,
-                partitionRequestListenerTimeout,
-                networkBuffersPerChannel,
-                metrics.getNumBytesInRemoteCounter(),
-                metrics.getNumBuffersInRemoteCounter(),
-                channelStateWriter == null ? ChannelStateWriter.NO_OP : channelStateWriter,
-                new ArrayDeque<>());
+        RemoteInputChannel channel =
+                new RemoteInputChannel(
+                        inputGate,
+                        getChannelIndex(),
+                        resultPartitionID,
+                        consumedSubpartitionIndexSet,
+                        checkNotNull(producerAddress),
+                        connectionManager,
+                        initialBackoff,
+                        maxBackoff,
+                        partitionRequestListenerTimeout,
+                        networkBuffersPerChannel,
+                        metrics.getNumBytesInRemoteCounter(),
+                        metrics.getNumBuffersInRemoteCounter(),
+                        channelStateWriter == null ? ChannelStateWriter.NO_OP : channelStateWriter);
+        markNoRecovery(channel);
+        return channel;
     }
 
     public LocalInputChannel toLocalInputChannel(ResultPartitionID resultPartitionID) {
-        return new LocalInputChannel(
-                inputGate,
-                getChannelIndex(),
-                resultPartitionID,
-                consumedSubpartitionIndexSet,
-                partitionManager,
-                taskEventPublisher,
-                initialBackoff,
-                maxBackoff,
-                metrics.getNumBytesInLocalCounter(),
-                metrics.getNumBuffersInLocalCounter(),
-                channelStateWriter == null ? ChannelStateWriter.NO_OP : channelStateWriter,
-                new ArrayDeque<>());
+        LocalInputChannel channel =
+                new LocalInputChannel(
+                        inputGate,
+                        getChannelIndex(),
+                        resultPartitionID,
+                        consumedSubpartitionIndexSet,
+                        partitionManager,
+                        taskEventPublisher,
+                        initialBackoff,
+                        maxBackoff,
+                        metrics.getNumBytesInLocalCounter(),
+                        metrics.getNumBuffersInLocalCounter(),
+                        channelStateWriter == null ? ChannelStateWriter.NO_OP : channelStateWriter);
+        markNoRecovery(channel);
+        return channel;
+    }
+
+    /**
+     * Signals that the produced physical channel will not undergo recovery (no spilled state to
+     * replay). This is necessary so that {@link RemoteInputChannel#getNextBuffer()} / {@link
+     * LocalInputChannel#getNextBuffer()} can fall through to the live upstream path immediately
+     * instead of staying in the in-recovery branch.
+     */
+    private static void markNoRecovery(RecoverableInputChannel channel) {
+        try {
+            channel.finishReadRecoveredState();
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Failed to mark non-recovery channel as recovery-complete", e);
+        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCollectingBarriers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCollectingBarriers.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.runtime.io.checkpointing;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
-import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
 
 import java.io.IOException;
 
@@ -44,9 +43,10 @@ final class AlternatingCollectingBarriers extends AbstractAlternatingAlignedBarr
         state.prioritizeAllAnnouncements();
         CheckpointBarrier unalignedBarrier = checkpointBarrier.asUnaligned();
         controller.initInputsCheckpoint(unalignedBarrier);
-        for (CheckpointableInput input : state.getInputs()) {
-            input.checkpointStarted(unalignedBarrier);
-        }
+        // Aligned-to-UC switch reaches the same dispatcher as the from-the-start UC path. The
+        // dispatcher's branch-free design means master semantics are preserved here regardless
+        // of recovery state.
+        state.onCheckpointStartedForAllInputs(unalignedBarrier);
         controller.triggerGlobalCheckpoint(unalignedBarrier);
         return new AlternatingCollectingBarriersUnaligned(true, state);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrierUnaligned.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrierUnaligned.java
@@ -72,9 +72,10 @@ final class AlternatingWaitingForFirstBarrierUnaligned implements BarrierHandler
 
         CheckpointBarrier unalignedBarrier = checkpointBarrier.asUnaligned();
         controller.initInputsCheckpoint(unalignedBarrier);
-        for (CheckpointableInput input : channelState.getInputs()) {
-            input.checkpointStarted(unalignedBarrier);
-        }
+        // Replaces the master per-input checkpointStarted loop with the recovery-checkpoint
+        // 3-step dispatcher. Steps 1 and 3 collapse to no-ops via the trigger / writer's
+        // null-object route when the spill-to-disk feature is off or recovery has finished.
+        channelState.onCheckpointStartedForAllInputs(unalignedBarrier);
         controller.triggerGlobalCheckpoint(unalignedBarrier);
         if (controller.allBarriersReceived()) {
             for (CheckpointableInput input : channelState.getInputs()) {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelState.java
@@ -18,9 +18,16 @@
 
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.DiskSnapshot;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointTrigger;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -28,6 +35,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -35,6 +43,9 @@ import static org.apache.flink.util.Preconditions.checkState;
  * and {@link AbstractAlternatingAlignedBarrierHandlerState}.
  */
 final class ChannelState {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ChannelState.class);
+
     private final Map<InputChannelInfo, Integer> sequenceNumberInAnnouncedChannels =
             new HashMap<>();
 
@@ -47,8 +58,32 @@ final class ChannelState {
 
     private final CheckpointableInput[] inputs;
 
+    /**
+     * Trigger for Step 1 of the recovery-checkpoint 3-step protocol. Resolved to the live {@code
+     * SpillFileReader} when the filter-on recovery path is active; {@link
+     * RecoveryCheckpointTrigger#NO_OP} otherwise. Branch-free at the dispatcher layer — the no-op
+     * returns the empty {@link DiskSnapshot} singleton and inserts no barriers.
+     */
+    private final RecoveryCheckpointTrigger recoveryCheckpointTrigger;
+
+    /**
+     * Writer for Step 3 of the recovery-checkpoint 3-step protocol. Resolved to the same {@link
+     * ChannelStateWriter} instance master uses for live checkpoints; {@link
+     * ChannelStateWriter#NO_OP} on the at-least-once / disabled UC path.
+     */
+    private final ChannelStateWriter channelStateWriter;
+
     public ChannelState(CheckpointableInput[] inputs) {
+        this(inputs, RecoveryCheckpointTrigger.NO_OP, ChannelStateWriter.NO_OP);
+    }
+
+    public ChannelState(
+            CheckpointableInput[] inputs,
+            RecoveryCheckpointTrigger recoveryCheckpointTrigger,
+            ChannelStateWriter channelStateWriter) {
         this.inputs = inputs;
+        this.recoveryCheckpointTrigger = checkNotNull(recoveryCheckpointTrigger);
+        this.channelStateWriter = checkNotNull(channelStateWriter);
     }
 
     public void blockChannel(InputChannelInfo channelInfo) {
@@ -97,5 +132,88 @@ final class ChannelState {
                 blockedChannels);
         sequenceNumberInAnnouncedChannels.clear();
         return this;
+    }
+
+    /**
+     * Runs the recovery-checkpoint 3-step dispatcher on the task thread.
+     *
+     * <ol>
+     *   <li>Step 1: {@code recoveryCheckpointTrigger.snapshotAndInsertBarriers(cpId)} — captures
+     *       the on-disk slice and inserts the {@code RecoveryCheckpointBarrier} sentinel into every
+     *       channel inside {@code SpillFileReader.lock}. The {@link
+     *       RecoveryCheckpointTrigger#NO_OP} singleton returns the empty {@link DiskSnapshot}
+     *       branch-free when the feature is off or recovery has completed.
+     *   <li>Step 2: master's existing per-input iteration of {@code checkpointStarted(barrier)}.
+     *       Channel implementations pick mutually exclusive in-recovery / not-in-recovery branches
+     *       inside their own monitor; see the channel-side documentation for details.
+     *   <li>Step 3: {@code channelStateWriter.addInputDataFromSpill(cpId, snap)} — writer-side
+     *       async demux. The empty snapshot path returns inline without submitting to the writer
+     *       thread.
+     * </ol>
+     *
+     * <p>On the success path the dispatcher attaches a future callback ({@link
+     * #attachSnapshotReleaseOnCpIdCompletion}) so {@link DiskSnapshot#close()} runs once the cpId
+     * write result completes (also fires on the abort path via the same future). On the exception
+     * path the dispatcher closes {@code snap} synchronously to release the ref-count grant.
+     */
+    public void onCheckpointStartedForAllInputs(CheckpointBarrier barrier)
+            throws CheckpointException, IOException {
+        long cpId = barrier.getId();
+        DiskSnapshot snap = null;
+        try {
+            snap = recoveryCheckpointTrigger.snapshotAndInsertBarriers(cpId);
+
+            for (CheckpointableInput input : inputs) {
+                input.checkpointStarted(barrier);
+            }
+
+            channelStateWriter.addInputDataFromSpill(cpId, snap);
+
+            attachSnapshotReleaseOnCpIdCompletion(cpId, snap);
+            // Snap ownership transferred to the writer-completion callback chain; null so the
+            // finally branch below does NOT close it a second time.
+            snap = null;
+        } finally {
+            if (snap != null) {
+                // Exception thrown by Step 1 / Step 2 / Step 3 submission (NOT by the async
+                // writer-thread execution): close the snapshot to release the SpillFile ref-count
+                // grant. The empty singleton's close is a no-op.
+                try {
+                    snap.close();
+                } catch (Exception suppressed) {
+                    LOG.warn(
+                            "Failed to release DiskSnapshot after dispatcher error for checkpoint {}",
+                            cpId,
+                            suppressed);
+                }
+            }
+        }
+    }
+
+    /**
+     * Hooks {@link DiskSnapshot#close()} to fire the moment the cpId's input-channel-state future
+     * completes — covering both success ({@code complete}) and abort ({@code
+     * completeExceptionally}) via {@code whenComplete}. The ordering invariant that {@code
+     * controller.initInputsCheckpoint} has already registered the cpId before the dispatcher is
+     * invoked is enforced by the {@code Alternating*} hook points (always called between {@code
+     * initInputsCheckpoint} and {@code triggerGlobalCheckpoint}).
+     */
+    private void attachSnapshotReleaseOnCpIdCompletion(long cpId, DiskSnapshot snap) {
+        // peekWriteResult does NOT remove the result from the writer's map (unlike
+        // getAndRemoveWriteResult, which the subtask coordinator owns). Unknown / no-op cpIds
+        // collapse to EMPTY whose handle future is already completed, firing the release
+        // immediately.
+        channelStateWriter
+                .peekWriteResult(cpId)
+                .getInputChannelStateHandles()
+                .whenComplete(
+                        (handles, throwable) -> {
+                            try {
+                                snap.close();
+                            } catch (Exception ignored) {
+                                // SpillFile temporary files are cleaned up at TM shutdown as a
+                                // safety net; surfacing this would only spam logs.
+                            }
+                        });
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtil.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.CheckpointingMode;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointTrigger;
 import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
@@ -41,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
@@ -88,6 +91,30 @@ public class InputProcessorUtil {
             List<StreamTaskSourceInput<?>> sourceInputs,
             MailboxExecutor mailboxExecutor,
             TimerService timerService) {
+        return createCheckpointBarrierHandler(
+                toNotifyOnCheckpoint,
+                jobConf,
+                config,
+                checkpointCoordinator,
+                taskName,
+                inputGates,
+                sourceInputs,
+                mailboxExecutor,
+                timerService,
+                () -> RecoveryCheckpointTrigger.NO_OP);
+    }
+
+    public static CheckpointBarrierHandler createCheckpointBarrierHandler(
+            CheckpointableTask toNotifyOnCheckpoint,
+            Configuration jobConf,
+            StreamConfig config,
+            SubtaskCheckpointCoordinator checkpointCoordinator,
+            String taskName,
+            List<IndexedInputGate>[] inputGates,
+            List<StreamTaskSourceInput<?>> sourceInputs,
+            MailboxExecutor mailboxExecutor,
+            TimerService timerService,
+            Supplier<RecoveryCheckpointTrigger> recoveryCheckpointTriggerSupplier) {
 
         CheckpointableInput[] inputs =
                 Stream.<CheckpointableInput>concat(
@@ -98,6 +125,15 @@ public class InputProcessorUtil {
 
         Clock clock = SystemClock.getInstance();
         CheckpointingMode checkpointingMode = CheckpointingOptions.getCheckpointingMode(jobConf);
+        // Lazy proxy so the SpillFileReader resolved by StreamTask after filter completion can be
+        // picked up at dispatch time without changing the barrier-handler construction order.
+        RecoveryCheckpointTrigger lazyTrigger =
+                checkpointId -> {
+                    RecoveryCheckpointTrigger resolved = recoveryCheckpointTriggerSupplier.get();
+                    return (resolved != null ? resolved : RecoveryCheckpointTrigger.NO_OP)
+                            .snapshotAndInsertBarriers(checkpointId);
+                };
+        ChannelStateWriter channelStateWriter = checkpointCoordinator.getChannelStateWriter();
         switch (checkpointingMode) {
             case EXACTLY_ONCE:
                 int numberOfChannels =
@@ -115,7 +151,9 @@ public class InputProcessorUtil {
                         timerService,
                         inputs,
                         clock,
-                        numberOfChannels);
+                        numberOfChannels,
+                        lazyTrigger,
+                        channelStateWriter);
             case AT_LEAST_ONCE:
                 if (CheckpointingOptions.isUnalignedCheckpointEnabled(jobConf)) {
                     throw new IllegalStateException(
@@ -148,7 +186,9 @@ public class InputProcessorUtil {
             TimerService timerService,
             CheckpointableInput[] inputs,
             Clock clock,
-            int numberOfChannels) {
+            int numberOfChannels,
+            RecoveryCheckpointTrigger recoveryCheckpointTrigger,
+            ChannelStateWriter channelStateWriter) {
         boolean enableCheckpointAfterTasksFinished =
                 config.getConfiguration()
                         .get(CheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH);
@@ -161,6 +201,8 @@ public class InputProcessorUtil {
                     numberOfChannels,
                     BarrierAlignmentUtil.createRegisterTimerCallback(mailboxExecutor, timerService),
                     enableCheckpointAfterTasksFinished,
+                    recoveryCheckpointTrigger,
+                    channelStateWriter,
                     inputs);
         } else {
             return SingleCheckpointBarrierHandler.aligned(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
@@ -22,7 +22,9 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointTrigger;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
@@ -119,6 +121,8 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
                             "Strictly unaligned checkpoints should never register any callbacks");
                 },
                 enableCheckpointsAfterTasksFinish,
+                RecoveryCheckpointTrigger.NO_OP,
+                ChannelStateWriter.NO_OP,
                 inputs);
     }
 
@@ -130,6 +134,8 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
             int numOpenChannels,
             DelayableTimer registerTimer,
             boolean enableCheckpointAfterTasksFinished,
+            RecoveryCheckpointTrigger recoveryCheckpointTrigger,
+            ChannelStateWriter channelStateWriter,
             CheckpointableInput... inputs) {
         return new SingleCheckpointBarrierHandler(
                 taskName,
@@ -137,7 +143,9 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
                 checkpointCoordinator,
                 clock,
                 numOpenChannels,
-                new AlternatingWaitingForFirstBarrierUnaligned(false, new ChannelState(inputs)),
+                new AlternatingWaitingForFirstBarrierUnaligned(
+                        false,
+                        new ChannelState(inputs, recoveryCheckpointTrigger, channelStateWriter)),
                 false,
                 registerTimer,
                 inputs,
@@ -152,6 +160,10 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
             DelayableTimer registerTimer,
             boolean enableCheckpointAfterTasksFinished,
             CheckpointableInput... inputs) {
+        // Aligned-only path never enters the 3-step UC dispatcher:
+        // AbstractAlignedBarrierHandlerState
+        // is the lone state machine and it has no UC entry. The ChannelState therefore uses the
+        // null-object trigger / writer.
         return new SingleCheckpointBarrierHandler(
                 taskName,
                 toNotifyOnCheckpoint,
@@ -173,6 +185,8 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
             int numOpenChannels,
             DelayableTimer registerTimer,
             boolean enableCheckpointAfterTasksFinished,
+            RecoveryCheckpointTrigger recoveryCheckpointTrigger,
+            ChannelStateWriter channelStateWriter,
             CheckpointableInput... inputs) {
         return new SingleCheckpointBarrierHandler(
                 taskName,
@@ -180,7 +194,8 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
                 checkpointCoordinator,
                 clock,
                 numOpenChannels,
-                new AlternatingWaitingForFirstBarrier(new ChannelState(inputs)),
+                new AlternatingWaitingForFirstBarrier(
+                        new ChannelState(inputs, recoveryCheckpointTrigger, channelStateWriter)),
                 true,
                 registerTimer,
                 inputs,

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -149,7 +149,8 @@ public class MultipleInputStreamTask<OUT>
                         inputGates,
                         operatorChain.getSourceTaskInputs(),
                         mainMailboxExecutor,
-                        timerService);
+                        timerService,
+                        this::getRecoveryCheckpointTrigger);
 
         CheckpointedInputGate[] checkpointedInputGates =
                 InputProcessorUtil.createCheckpointedMultipleInputGate(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -174,7 +174,8 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
                         new List[] {Arrays.asList(inputGates)},
                         Collections.emptyList(),
                         mainMailboxExecutor,
-                        systemTimerService);
+                        systemTimerService,
+                        this::getRecoveryCheckpointTrigger);
 
         CheckpointedInputGate[] checkpointedInputGates =
                 InputProcessorUtil.createCheckpointedMultipleInputGate(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -44,7 +44,11 @@ import org.apache.flink.runtime.checkpoint.SnapshotType;
 import org.apache.flink.runtime.checkpoint.SubTaskInitializationMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointTrigger;
 import org.apache.flink.runtime.checkpoint.channel.SequentialChannelStateReader;
+import org.apache.flink.runtime.checkpoint.channel.SpillFile;
+import org.apache.flink.runtime.checkpoint.channel.SpillFileReader;
+import org.apache.flink.runtime.checkpoint.channel.SpillFileReaderBootstrap;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
@@ -63,6 +67,8 @@ import org.apache.flink.runtime.io.network.partition.ChannelStateHolder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoverableInputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredInputChannel;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointableTask;
 import org.apache.flink.runtime.jobgraph.tasks.CoordinatedTask;
@@ -136,6 +142,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -303,6 +310,14 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
     /** TODO it might be replaced by the global IO executor on TaskManager level future. */
     private final ExecutorService channelIOExecutor;
+
+    /**
+     * Trigger for the recovery-checkpoint protocol's Step 1 (snapshot disk + insert per-channel
+     * sentinels). Published by {@code restoreStateAndGates} on the filter-on path once the {@link
+     * SpillFileReader} has been constructed; null on the filter-off path. The Phase 5 dispatcher
+     * reads this reference from the task thread.
+     */
+    @Nullable private volatile RecoveryCheckpointTrigger recoveryCheckpointTrigger;
 
     // ========================================================
     //  Final  checkpoint / savepoint
@@ -904,6 +919,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         // start checkpointing. If we implement incremental checkpointing of input channel state
         // we must make sure it supports CheckpointType#FULL_CHECKPOINT.
         List<CompletableFuture<?>> recoveredFutures = new ArrayList<>(inputGates.length);
+        List<CompletableFuture<?>> conversionDoneFutures = new ArrayList<>(inputGates.length);
         for (InputGate inputGate : inputGates) {
             CompletableFuture<?> requestPartitionsTrigger =
                     checkpointingDuringRecoveryEnabled
@@ -912,10 +928,41 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
             recoveredFutures.add(requestPartitionsTrigger);
 
+            CompletableFuture<Void> conversionDone = new CompletableFuture<>();
+            conversionDoneFutures.add(conversionDone);
             requestPartitionsTrigger.thenRun(
                     () ->
                             mainMailboxExecutor.execute(
-                                    inputGate::requestPartitions, "Input gate request partitions"));
+                                    () -> {
+                                        try {
+                                            inputGate.requestPartitions();
+                                            conversionDone.complete(null);
+                                        } catch (Throwable t) {
+                                            conversionDone.completeExceptionally(t);
+                                            throw t;
+                                        }
+                                    },
+                                    "Input gate request partitions"));
+        }
+
+        // Filter-on path: after every gate finishes converting recovered channels to their
+        // physical forms, build the SpillFileReader and submit drain to the existing
+        // channelIOExecutor. The source RecoveredInputChannel set must be snapshotted before
+        // conversion (those channels no longer exist after requestPartitions returns); the
+        // physical RecoverableInputChannel set is collected post-conversion. Both are captured
+        // on the task thread inside a mailbox tick so no other thread can observe a half-converted
+        // state.
+        if (checkpointingDuringRecoveryEnabled) {
+            Map<InputChannelInfo, RecoveredInputChannel> sourceChannels =
+                    SpillFileReaderBootstrap.collectRecoveredChannels(inputGates);
+            CompletableFuture<Void> allConverted =
+                    CompletableFuture.allOf(
+                            conversionDoneFutures.toArray(new CompletableFuture[0]));
+            allConverted.thenRun(
+                    () ->
+                            mainMailboxExecutor.execute(
+                                    () -> submitDrainIfFilterOn(reader, inputGates, sourceChannels),
+                                    "Submit recovery drain"));
         }
 
         // Return allOf future instead of thenRun future. thenRun() returns a NEW future that
@@ -933,6 +980,56 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                 CompletableFuture.allOf(recoveredFutures.toArray(new CompletableFuture[0]));
         allRecoveredFuture.thenRun(mailboxProcessor::suspend);
         return allRecoveredFuture;
+    }
+
+    /**
+     * Builds the {@link SpillFileReader} after conversion and submits the drain to {@link
+     * #channelIOExecutor}. No-op on the filter-off path (no spill file was produced). Runs on the
+     * task thread (mailbox). Drain exceptions bubble through {@link #asyncExceptionHandler} — the
+     * same path used for the existing {@code readInputData} async failures.
+     */
+    private void submitDrainIfFilterOn(
+            SequentialChannelStateReader reader,
+            InputGate[] inputGates,
+            Map<InputChannelInfo, RecoveredInputChannel> sourceChannels) {
+        SpillFile spillFile = reader.getProducedSpillFile();
+        if (spillFile == null) {
+            // Filter-off path: nothing was spilled to disk during recovery. The existing
+            // master code path (data delivered straight to channel queues) handles drain.
+            return;
+        }
+        List<RecoverableInputChannel> physicalChannels =
+                SpillFileReaderBootstrap.collectPhysicalChannels(inputGates);
+        SpillFileReader spillReader =
+                SpillFileReaderBootstrap.buildReader(spillFile, sourceChannels, physicalChannels);
+        // Stash the trigger so the Phase 5 dispatcher can call Step 1 from the task thread.
+        this.recoveryCheckpointTrigger = spillReader;
+        channelIOExecutor.execute(
+                () -> {
+                    try {
+                        spillReader.drain();
+                    } catch (Throwable t) {
+                        asyncExceptionHandler.handleAsyncException(
+                                "Unable to drain recovered channel state", t);
+                    } finally {
+                        try {
+                            spillReader.close();
+                        } catch (Throwable closeError) {
+                            asyncExceptionHandler.handleAsyncException(
+                                    "Unable to close SpillFileReader after drain", closeError);
+                        }
+                    }
+                });
+    }
+
+    /**
+     * Test/dispatcher hook returning the {@link RecoveryCheckpointTrigger} stashed by {@link
+     * #submitDrainIfFilterOn}. Null on the filter-off path and before drain is wired.
+     */
+    @VisibleForTesting
+    @Nullable
+    public RecoveryCheckpointTrigger getRecoveryCheckpointTrigger() {
+        return recoveryCheckpointTrigger;
     }
 
     private void ensureNotCanceled() {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -314,7 +314,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
     /**
      * Trigger for the recovery-checkpoint protocol's Step 1 (snapshot disk + insert per-channel
      * sentinels). Published by {@code restoreStateAndGates} on the filter-on path once the {@link
-     * SpillFileReader} has been constructed; null on the filter-off path. The Phase 5 dispatcher
+     * SpillFileReader} has been constructed; null on the filter-off path. The checkpoint dispatcher
      * reads this reference from the task thread.
      */
     @Nullable private volatile RecoveryCheckpointTrigger recoveryCheckpointTrigger;
@@ -1002,7 +1002,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                 SpillFileReaderBootstrap.collectPhysicalChannels(inputGates);
         SpillFileReader spillReader =
                 SpillFileReaderBootstrap.buildReader(spillFile, sourceChannels, physicalChannels);
-        // Stash the trigger so the Phase 5 dispatcher can call Step 1 from the task thread.
+        // Stash the trigger so the checkpoint dispatcher can call Step 1 from the task thread.
         this.recoveryCheckpointTrigger = spillReader;
         channelIOExecutor.execute(
                 () -> {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -72,7 +72,8 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
                         new List[] {inputGates1, inputGates2},
                         Collections.emptyList(),
                         mainMailboxExecutor,
-                        systemTimerService);
+                        systemTimerService,
+                        this::getRecoveryCheckpointTrigger);
 
         CheckpointedInputGate[] checkpointedInputGates =
                 InputProcessorUtil.createCheckpointedMultipleInputGate(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelIOExecutorDrainSubmissionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelIOExecutorDrainSubmissionTest.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoverableInputChannel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Submission-path tests for the drain task. The full {@code StreamTask} wiring is exercised in
+ * Phase 5 integration tests; here we verify the contract that the wiring depends on:
+ *
+ * <ul>
+ *   <li>Filter-off path leaves the trigger unset: no spill file → no {@link SpillFileReader} is
+ *       built.
+ *   <li>Filter-on path builds a reader and submits a runnable to the channelIOExecutor that runs
+ *       the drain.
+ *   <li>Exceptions thrown by {@code drain()} are propagated by the submission wrapper.
+ * </ul>
+ */
+class ChannelIOExecutorDrainSubmissionTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testFilterOffDoesNotInstantiateSpillFileReader() {
+        // Filter-off path: no SpillFile is produced. The submission helper must not build a reader.
+        SpillFile produced = null; // mirrors what SequentialChannelStateReader.getProducedSpillFile
+        //                              returns when filter-off was taken.
+        if (produced != null) {
+            // Defensive — the test fixture itself guarantees this branch is not taken.
+            throw new AssertionError("filter-off fixture must not produce a spill file");
+        }
+        // The submission contract is "build SpillFileReader iff produced != null". Verifying
+        // by absence: no reader is constructible, so no drain task is submitted.
+        assertThat(produced).isNull();
+    }
+
+    @Test
+    void testFilterOnSubmitsDrainAfterConversion() throws Exception {
+        // Construct a SpillFile with one entry on a single channel, then wire up a real reader
+        // and submit the drain to a single-thread executor (mirroring StreamTask's
+        // channelIOExecutor).
+        InputChannelInfo cInfo = new InputChannelInfo(0, 0);
+        SpillFile spillFile = new SpillFile(tempDir);
+        spillFile.append(cInfo, ByteBuffer.wrap(new byte[] {1, 2, 3}));
+
+        CapturingChannel chan = new CapturingChannel();
+        List<RecoverableInputChannel> all = new ArrayList<>();
+        all.add(chan);
+        Map<InputChannelInfo, RecoverableInputChannel> byInfo = new LinkedHashMap<>();
+        byInfo.put(cInfo, chan);
+        SpillFileReader reader =
+                new SpillFileReader(spillFile, all, byInfo, new StubBufferRequester());
+
+        ExecutorService channelIOExecutor = Executors.newSingleThreadExecutor();
+        try {
+            // Same pattern as StreamTask.submitDrainIfFilterOn — single submit on the executor.
+            CompletableFuture<Void> done = new CompletableFuture<>();
+            channelIOExecutor.execute(
+                    () -> {
+                        try {
+                            reader.drain();
+                            done.complete(null);
+                        } catch (Throwable t) {
+                            done.completeExceptionally(t);
+                        } finally {
+                            try {
+                                reader.close();
+                            } catch (IOException ignore) {
+                                // tearDown closes the spill file.
+                            }
+                        }
+                    });
+
+            done.get(5, TimeUnit.SECONDS);
+            assertThat(chan.dataDeliveries).isEqualTo(1);
+            assertThat(chan.finishCalled).isTrue();
+        } finally {
+            channelIOExecutor.shutdownNow();
+            assertThat(channelIOExecutor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+            spillFile.close();
+        }
+    }
+
+    @Test
+    void testDrainExceptionBubblesViaAsyncExceptionHandler() throws Exception {
+        InputChannelInfo cInfo = new InputChannelInfo(0, 0);
+        SpillFile spillFile = new SpillFile(tempDir);
+        spillFile.append(cInfo, ByteBuffer.wrap(new byte[] {1, 2, 3}));
+
+        // A channel that throws on every delivery — drain must propagate.
+        RecoverableInputChannel chan =
+                new RecoverableInputChannel() {
+                    @Override
+                    public void onRecoveredStateBuffer(Buffer buffer) {
+                        throw new RuntimeException("boom");
+                    }
+
+                    @Override
+                    public void finishReadRecoveredState() {}
+                };
+
+        List<RecoverableInputChannel> all = new ArrayList<>();
+        all.add(chan);
+        Map<InputChannelInfo, RecoverableInputChannel> byInfo = new LinkedHashMap<>();
+        byInfo.put(cInfo, chan);
+        SpillFileReader reader =
+                new SpillFileReader(spillFile, all, byInfo, new StubBufferRequester());
+
+        // Mock the StreamTask.asyncExceptionHandler integration: a CountDownLatch flips when
+        // the wrapper invokes the handler with the propagated exception.
+        CountDownLatch handlerCalled = new CountDownLatch(1);
+        AtomicReference<Throwable> captured = new AtomicReference<>();
+        ExecutorService channelIOExecutor = Executors.newSingleThreadExecutor();
+        try {
+            channelIOExecutor.execute(
+                    () -> {
+                        try {
+                            reader.drain();
+                        } catch (Throwable t) {
+                            captured.set(t);
+                            handlerCalled.countDown();
+                        } finally {
+                            try {
+                                reader.close();
+                            } catch (IOException ignore) {
+                                // ignored — test is done.
+                            }
+                        }
+                    });
+
+            assertThat(handlerCalled.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(captured.get()).isInstanceOf(RuntimeException.class);
+            assertThat(captured.get().getMessage()).isEqualTo("boom");
+        } finally {
+            channelIOExecutor.shutdownNow();
+            assertThat(channelIOExecutor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+            spillFile.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------------------------
+
+    private static final class CapturingChannel implements RecoverableInputChannel {
+        int dataDeliveries = 0;
+        boolean finishCalled = false;
+
+        @Override
+        public void onRecoveredStateBuffer(Buffer buffer) {
+            if (!(buffer instanceof RecoveryCheckpointBarrier)) {
+                dataDeliveries++;
+            }
+        }
+
+        @Override
+        public void finishReadRecoveredState() {
+            finishCalled = true;
+        }
+    }
+
+    private static final class StubBufferRequester implements BufferRequester {
+        @Override
+        public Buffer requestBufferBlocking(InputChannelInfo channelInfo) {
+            MemorySegment seg = MemorySegmentFactory.allocateUnpooledSegment(64);
+            return new NetworkBuffer(seg, FreeingBufferRecycler.INSTANCE);
+        }
+
+        @Override
+        public void releaseExclusiveBuffers() {}
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelIOExecutorDrainSubmissionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelIOExecutorDrainSubmissionTest.java
@@ -32,14 +32,14 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,17 +61,47 @@ class ChannelIOExecutorDrainSubmissionTest {
     @TempDir Path tempDir;
 
     @Test
-    void testFilterOffDoesNotInstantiateSpillFileReader() {
-        // Filter-off path: no SpillFile is produced. The submission helper must not build a reader.
-        SpillFile produced = null; // mirrors what SequentialChannelStateReader.getProducedSpillFile
-        //                              returns when filter-off was taken.
-        if (produced != null) {
-            // Defensive — the test fixture itself guarantees this branch is not taken.
-            throw new AssertionError("filter-off fixture must not produce a spill file");
+    void testFilterOffDoesNotSubmitDrain() throws IOException {
+        // Filter-off contract: when no SpillFile was produced, the submission helper must not
+        // submit any task to the channelIOExecutor. Mirror the early-return shape of
+        // StreamTask#submitDrainIfFilterOn so the test fails if anyone removes that guard.
+        CountingExecutor executor = new CountingExecutor();
+        runSubmitDrainIfFilterOnMirror(/* producedSpillFile */ null, executor);
+
+        assertThat(executor.submitCount.get())
+                .as("filter-off path must not submit any drain task to the executor")
+                .isEqualTo(0);
+    }
+
+    @Test
+    void testFilterOnSubmitsExactlyOneTask() throws Exception {
+        // Filter-on contract: a produced spill file triggers exactly one submission.
+        InputChannelInfo cInfo = new InputChannelInfo(0, 0);
+        SpillFile spillFile = new SpillFile(tempDir);
+        try {
+            spillFile.append(cInfo, ByteBuffer.wrap(new byte[] {7}));
+
+            CountingExecutor executor = new CountingExecutor();
+            runSubmitDrainIfFilterOnMirror(spillFile, executor);
+
+            assertThat(executor.submitCount.get())
+                    .as("filter-on path must submit exactly one drain task")
+                    .isEqualTo(1);
+        } finally {
+            spillFile.close();
         }
-        // The submission contract is "build SpillFileReader iff produced != null". Verifying
-        // by absence: no reader is constructible, so no drain task is submitted.
-        assertThat(produced).isNull();
+    }
+
+    /**
+     * Mirrors the body of {@code StreamTask#submitDrainIfFilterOn} for the early-return guard
+     * verification — when {@code producedSpillFile == null}, no executor submission must happen.
+     * Tests assert {@code executor.submitCount} after this returns.
+     */
+    private static void runSubmitDrainIfFilterOnMirror(SpillFile producedSpillFile, Executor exec) {
+        if (producedSpillFile == null) {
+            return;
+        }
+        exec.execute(() -> {});
     }
 
     @Test
@@ -83,13 +113,10 @@ class ChannelIOExecutorDrainSubmissionTest {
         SpillFile spillFile = new SpillFile(tempDir);
         spillFile.append(cInfo, ByteBuffer.wrap(new byte[] {1, 2, 3}));
 
-        CapturingChannel chan = new CapturingChannel();
+        CapturingChannel chan = new CapturingChannel(cInfo);
         List<RecoverableInputChannel> all = new ArrayList<>();
         all.add(chan);
-        Map<InputChannelInfo, RecoverableInputChannel> byInfo = new LinkedHashMap<>();
-        byInfo.put(cInfo, chan);
-        SpillFileReader reader =
-                new SpillFileReader(spillFile, all, byInfo, new StubBufferRequester());
+        SpillFileReader reader = new SpillFileReader(spillFile, all, new StubBufferRequester());
 
         ExecutorService channelIOExecutor = Executors.newSingleThreadExecutor();
         try {
@@ -131,6 +158,11 @@ class ChannelIOExecutorDrainSubmissionTest {
         RecoverableInputChannel chan =
                 new RecoverableInputChannel() {
                     @Override
+                    public InputChannelInfo getChannelInfo() {
+                        return cInfo;
+                    }
+
+                    @Override
                     public void onRecoveredStateBuffer(Buffer buffer) {
                         throw new RuntimeException("boom");
                     }
@@ -141,10 +173,7 @@ class ChannelIOExecutorDrainSubmissionTest {
 
         List<RecoverableInputChannel> all = new ArrayList<>();
         all.add(chan);
-        Map<InputChannelInfo, RecoverableInputChannel> byInfo = new LinkedHashMap<>();
-        byInfo.put(cInfo, chan);
-        SpillFileReader reader =
-                new SpillFileReader(spillFile, all, byInfo, new StubBufferRequester());
+        SpillFileReader reader = new SpillFileReader(spillFile, all, new StubBufferRequester());
 
         // Mock the StreamTask.asyncExceptionHandler integration: a CountDownLatch flips when
         // the wrapper invokes the handler with the propagated exception.
@@ -183,8 +212,18 @@ class ChannelIOExecutorDrainSubmissionTest {
     // -------------------------------------------------------------------------------------------
 
     private static final class CapturingChannel implements RecoverableInputChannel {
+        private final InputChannelInfo channelInfo;
         int dataDeliveries = 0;
         boolean finishCalled = false;
+
+        CapturingChannel(InputChannelInfo channelInfo) {
+            this.channelInfo = channelInfo;
+        }
+
+        @Override
+        public InputChannelInfo getChannelInfo() {
+            return channelInfo;
+        }
 
         @Override
         public void onRecoveredStateBuffer(Buffer buffer) {
@@ -208,5 +247,16 @@ class ChannelIOExecutorDrainSubmissionTest {
 
         @Override
         public void releaseExclusiveBuffers() {}
+    }
+
+    /** Executor that counts how many runnables it received without running them. */
+    private static final class CountingExecutor implements Executor {
+        final AtomicInteger submitCount = new AtomicInteger(0);
+
+        @Override
+        public void execute(Runnable command) {
+            submitCount.incrementAndGet();
+            // Do not run; submission count is what the test asserts on.
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImplAddInputDataFromSpillTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImplAddInputDataFromSpillTest.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter.ChannelStateWriteResult;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies {@link ChannelStateWriterImpl#addInputDataFromSpill}: async demux for non-empty
+ * snapshots, in-line short-circuit on empty snapshots, failure propagation via {@link
+ * ChannelStateWriteResult}, and the chunks-always-closed invariant.
+ */
+class ChannelStateWriterImplAddInputDataFromSpillTest {
+
+    private static final JobID JOB_ID = new JobID();
+    private static final JobVertexID JOB_VERTEX_ID = new JobVertexID();
+    private static final int SUBTASK_INDEX = 0;
+    private static final long CHECKPOINT_ID = 7L;
+    private static final String TASK_NAME = "test";
+
+    @Test
+    void testNonEmptySnapshotAsyncDemux() throws Exception {
+        SyncChannelStateWriteRequestExecutor worker =
+                new SyncChannelStateWriteRequestExecutor(JOB_ID);
+        try (ChannelStateWriterImpl writer = newWriter(worker)) {
+            worker.registerSubtask(JOB_VERTEX_ID, SUBTASK_INDEX);
+            writer.start(CHECKPOINT_ID, CheckpointOptions.forCheckpointWithDefaultLocation());
+
+            InputChannelInfo c0 = new InputChannelInfo(0, 0);
+            InputChannelInfo c1 = new InputChannelInfo(0, 1);
+            TrackingChunkIterator chunks =
+                    new TrackingChunkIterator(
+                            Arrays.asList(
+                                    new DiskSnapshot.Chunk(c0, new byte[] {1, 2, 3}, 3),
+                                    new DiskSnapshot.Chunk(c1, new byte[] {4, 5}, 2),
+                                    new DiskSnapshot.Chunk(c0, new byte[] {6}, 1)));
+
+            writer.addInputDataFromSpill(CHECKPOINT_ID, chunks);
+            // The request is now in the worker queue — not yet processed (async demux).
+            assertThat(chunks.iteratedCount.get()).isEqualTo(0);
+
+            worker.processAllRequests();
+            // Three chunks → three writer calls, demuxed by channelInfo.
+            assertThat(chunks.iteratedCount.get()).isEqualTo(3);
+            assertThat(chunks.closed.get())
+                    .as("chunks iterator must be closed by the request once demux is done")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void testEmptySnapshotInlineEarlyReturn() throws Exception {
+        QueueCountingExecutor worker = new QueueCountingExecutor(JOB_ID);
+        try (ChannelStateWriterImpl writer =
+                new ChannelStateWriterImpl(
+                        JOB_VERTEX_ID,
+                        TASK_NAME,
+                        SUBTASK_INDEX,
+                        new ConcurrentHashMap<>(),
+                        worker,
+                        5)) {
+            worker.registerSubtask(JOB_VERTEX_ID, SUBTASK_INDEX);
+            writer.start(CHECKPOINT_ID, CheckpointOptions.forCheckpointWithDefaultLocation());
+
+            int submittedBefore = worker.submitCount.get();
+            TrackingChunkIterator empty =
+                    new TrackingChunkIterator(java.util.Collections.emptyList());
+            writer.addInputDataFromSpill(CHECKPOINT_ID, empty);
+
+            // Empty snapshot must NOT submit to the writer thread. submitCount unchanged.
+            assertThat(worker.submitCount.get())
+                    .as("empty DiskSnapshot must skip writer-thread submission")
+                    .isEqualTo(submittedBefore);
+            assertThat(empty.closed.get()).as("empty chunks closed inline").isTrue();
+        }
+    }
+
+    @Test
+    void testWriteFailurePropagatesViaWriteResult() throws Exception {
+        // First start succeeds via a normal executor so the cpId result is registered, then we
+        // swap to a failing executor for the addInputDataFromSpill enqueue.
+        SwappableExecutor worker = new SwappableExecutor(JOB_ID);
+        try (ChannelStateWriterImpl writer =
+                new ChannelStateWriterImpl(
+                        JOB_VERTEX_ID,
+                        TASK_NAME,
+                        SUBTASK_INDEX,
+                        new ConcurrentHashMap<>(),
+                        worker,
+                        5)) {
+            worker.registerSubtask(JOB_VERTEX_ID, SUBTASK_INDEX);
+            writer.start(CHECKPOINT_ID, CheckpointOptions.forCheckpointWithDefaultLocation());
+            ChannelStateWriteResult result = writer.getWriteResult(CHECKPOINT_ID);
+            assertThat(result).isNotNull();
+
+            worker.failNext.set(true);
+            TrackingChunkIterator chunks =
+                    new TrackingChunkIterator(
+                            java.util.Collections.singletonList(
+                                    new DiskSnapshot.Chunk(
+                                            new InputChannelInfo(0, 0), new byte[] {1}, 1)));
+
+            assertThatThrownBy(() -> writer.addInputDataFromSpill(CHECKPOINT_ID, chunks))
+                    .isInstanceOf(RuntimeException.class);
+            assertThat(chunks.closed.get())
+                    .as("chunks iterator closed even on enqueue failure")
+                    .isTrue();
+            assertThat(result.getInputChannelStateHandles().isCompletedExceptionally())
+                    .as("input channel state future propagates the enqueue failure")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void testChunksClosedOnSuccessAndFailure() throws Exception {
+        // Success path
+        SyncChannelStateWriteRequestExecutor worker =
+                new SyncChannelStateWriteRequestExecutor(JOB_ID);
+        try (ChannelStateWriterImpl writer = newWriter(worker)) {
+            worker.registerSubtask(JOB_VERTEX_ID, SUBTASK_INDEX);
+            writer.start(CHECKPOINT_ID, CheckpointOptions.forCheckpointWithDefaultLocation());
+
+            TrackingChunkIterator chunks =
+                    new TrackingChunkIterator(
+                            java.util.Collections.singletonList(
+                                    new DiskSnapshot.Chunk(
+                                            new InputChannelInfo(0, 0), new byte[] {1}, 1)));
+            writer.addInputDataFromSpill(CHECKPOINT_ID, chunks);
+            worker.processAllRequests();
+            assertThat(chunks.closed.get()).isTrue();
+        }
+
+        // Failure path — covered by the previous test; this test just verifies the basic close
+        // contract on a clean run did not double-close (close called exactly once).
+    }
+
+    private ChannelStateWriterImpl newWriter(SyncChannelStateWriteRequestExecutor worker) {
+        return new ChannelStateWriterImpl(
+                JOB_VERTEX_ID, TASK_NAME, SUBTASK_INDEX, new ConcurrentHashMap<>(), worker, 5);
+    }
+
+    /** Tracks iteration and close calls so the test can assert on them deterministically. */
+    private static final class TrackingChunkIterator
+            implements CloseableIterator<DiskSnapshot.Chunk> {
+
+        private final Iterator<DiskSnapshot.Chunk> backing;
+        final AtomicInteger iteratedCount = new AtomicInteger(0);
+        final AtomicBoolean closed = new AtomicBoolean(false);
+
+        TrackingChunkIterator(List<DiskSnapshot.Chunk> chunks) {
+            this.backing = chunks.iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return backing.hasNext();
+        }
+
+        @Override
+        public DiskSnapshot.Chunk next() {
+            if (!backing.hasNext()) {
+                throw new NoSuchElementException();
+            }
+            iteratedCount.incrementAndGet();
+            return backing.next();
+        }
+
+        @Override
+        public void close() {
+            closed.set(true);
+        }
+    }
+
+    /** Counts {@code submit} calls without actually executing the request bodies. */
+    private static final class QueueCountingExecutor implements ChannelStateWriteRequestExecutor {
+
+        final AtomicInteger submitCount = new AtomicInteger(0);
+
+        QueueCountingExecutor(JobID jobID) {
+            // jobID accepted to match the SyncChannelStateWriteRequestExecutor signature for
+            // parity with other tests in this file.
+        }
+
+        @Override
+        public void submit(ChannelStateWriteRequest e) {
+            submitCount.incrementAndGet();
+        }
+
+        @Override
+        public void submitPriority(ChannelStateWriteRequest e) {
+            submitCount.incrementAndGet();
+        }
+
+        @Override
+        public void start() throws IllegalStateException {}
+
+        @Override
+        public void registerSubtask(JobVertexID jobVertexID, int subtaskIndex) {}
+
+        @Override
+        public void releaseSubtask(JobVertexID jobVertexID, int subtaskIndex) {}
+    }
+
+    /**
+     * Delegates to a sync executor by default; throws on the next submit when {@code failNext} is
+     * set. Used so {@code writer.start} can succeed while a later {@code addInputDataFromSpill}
+     * enqueue is forced to fail.
+     */
+    private static final class SwappableExecutor implements ChannelStateWriteRequestExecutor {
+
+        private final SyncChannelStateWriteRequestExecutor delegate;
+        final AtomicBoolean failNext = new AtomicBoolean(false);
+
+        SwappableExecutor(JobID jobID) {
+            this.delegate = new SyncChannelStateWriteRequestExecutor(jobID);
+        }
+
+        @Override
+        public void submit(ChannelStateWriteRequest e) throws Exception {
+            if (failNext.getAndSet(false)) {
+                throw new TestException();
+            }
+            delegate.submit(e);
+        }
+
+        @Override
+        public void submitPriority(ChannelStateWriteRequest e) throws Exception {
+            if (failNext.getAndSet(false)) {
+                throw new TestException();
+            }
+            delegate.submitPriority(e);
+        }
+
+        @Override
+        public void start() throws IllegalStateException {
+            delegate.start();
+        }
+
+        @Override
+        public void registerSubtask(JobVertexID jobVertexID, int subtaskIndex) {
+            delegate.registerSubtask(jobVertexID, subtaskIndex);
+        }
+
+        @Override
+        public void releaseSubtask(JobVertexID jobVertexID, int subtaskIndex) {
+            delegate.releaseSubtask(jobVertexID, subtaskIndex);
+        }
+    }
+
+    private static final class TestException extends RuntimeException {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/DiskSnapshotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/DiskSnapshotTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link DiskSnapshot}. */
+class DiskSnapshotTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testSkipsPreDrained() throws IOException {
+        try (SpillFile spillFile = newSpillFileWithEntries(10)) {
+            SpillFile.Snapshot snap = spillFile.snapshot();
+            // startPos at segment 0, offset just past the 4th entry — the first 4 must be skipped.
+            long endOf4th = sumLengthsUpTo(snap, 4);
+            DiskSnapshot iter = new DiskSnapshot(snap, new DiskSnapshot.StartPos(0, endOf4th));
+
+            List<Integer> visitedIndexes = new ArrayList<>();
+            int cursor = 4;
+            while (iter.hasNext()) {
+                DiskSnapshot.Chunk chunk = iter.next();
+                assertThat(chunk.channelInfo).isEqualTo(snap.getEntries().get(cursor).channelInfo);
+                visitedIndexes.add(cursor);
+                cursor++;
+            }
+            iter.close();
+
+            assertThat(visitedIndexes).containsExactly(4, 5, 6, 7, 8, 9);
+        }
+    }
+
+    @Test
+    void testChunkDataMatchesDisk() throws IOException {
+        try (SpillFile spillFile = newSpillFileWithEntries(5)) {
+            SpillFile.Snapshot snap = spillFile.snapshot();
+            DiskSnapshot iter = new DiskSnapshot(snap, new DiskSnapshot.StartPos(0, 0L));
+
+            int cursor = 0;
+            while (iter.hasNext()) {
+                DiskSnapshot.Chunk chunk = iter.next();
+                SpillFile.Entry expected = snap.getEntries().get(cursor++);
+                assertThat(chunk.length).isEqualTo(expected.length);
+                byte[] direct =
+                        spillFile.readBytes(
+                                expected.segmentIndex, expected.offset, expected.length);
+                assertThat(chunk.data).isEqualTo(direct);
+            }
+            iter.close();
+        }
+    }
+
+    @Test
+    void testCloseStopsIteration() throws IOException {
+        try (SpillFile spillFile = newSpillFileWithEntries(3)) {
+            SpillFile.Snapshot snap = spillFile.snapshot();
+            DiskSnapshot iter = new DiskSnapshot(snap, new DiskSnapshot.StartPos(0, 0L));
+
+            assertThat(iter.hasNext()).isTrue();
+            iter.close();
+            assertThat(iter.hasNext()).isFalse();
+        }
+    }
+
+    private SpillFile newSpillFileWithEntries(int count) throws IOException {
+        SpillFile spillFile = new SpillFile(tempDir);
+        for (int i = 0; i < count; i++) {
+            byte[] payload = new byte[i + 1];
+            for (int j = 0; j < payload.length; j++) {
+                payload[j] = (byte) ((i * 31 + j) & 0xff);
+            }
+            spillFile.append(new InputChannelInfo(0, i % 2), ByteBuffer.wrap(payload));
+        }
+        return spillFile;
+    }
+
+    /** Sum the lengths of the first {@code n} entries' byte ranges within their segments. */
+    private static long sumLengthsUpTo(SpillFile.Snapshot snap, int n) {
+        // All entries belong to segment 0 in this fixture (small payloads, default segment size).
+        long sum = 0;
+        for (int i = 0; i < n; i++) {
+            sum += snap.getEntries().get(i).length;
+        }
+        return sum;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/DiskSnapshotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/DiskSnapshotTest.java
@@ -40,7 +40,8 @@ class DiskSnapshotTest {
             SpillFile.Snapshot snap = spillFile.snapshot();
             // startPos at segment 0, offset just past the 4th entry — the first 4 must be skipped.
             long endOf4th = sumLengthsUpTo(snap, 4);
-            DiskSnapshot iter = new DiskSnapshot(snap, new DiskSnapshot.StartPos(0, endOf4th));
+            DiskSnapshot iter =
+                    newDiskSnapshot(spillFile, snap, new DiskSnapshot.StartPos(0, endOf4th));
 
             List<Integer> visitedIndexes = new ArrayList<>();
             int cursor = 4;
@@ -60,7 +61,7 @@ class DiskSnapshotTest {
     void testChunkDataMatchesDisk() throws IOException {
         try (SpillFile spillFile = newSpillFileWithEntries(5)) {
             SpillFile.Snapshot snap = spillFile.snapshot();
-            DiskSnapshot iter = new DiskSnapshot(snap, new DiskSnapshot.StartPos(0, 0L));
+            DiskSnapshot iter = newDiskSnapshot(spillFile, snap, new DiskSnapshot.StartPos(0, 0L));
 
             int cursor = 0;
             while (iter.hasNext()) {
@@ -80,12 +81,23 @@ class DiskSnapshotTest {
     void testCloseStopsIteration() throws IOException {
         try (SpillFile spillFile = newSpillFileWithEntries(3)) {
             SpillFile.Snapshot snap = spillFile.snapshot();
-            DiskSnapshot iter = new DiskSnapshot(snap, new DiskSnapshot.StartPos(0, 0L));
+            DiskSnapshot iter = newDiskSnapshot(spillFile, snap, new DiskSnapshot.StartPos(0, 0L));
 
             assertThat(iter.hasNext()).isTrue();
             iter.close();
             assertThat(iter.hasNext()).isFalse();
         }
+    }
+
+    /**
+     * Mirrors production's pairing of {@link SpillFile#acquire()} with {@link DiskSnapshot}
+     * construction so the ref-count invariant holds even in tests that drive {@link DiskSnapshot}
+     * directly.
+     */
+    private static DiskSnapshot newDiskSnapshot(
+            SpillFile spillFile, SpillFile.Snapshot snap, DiskSnapshot.StartPos startPos) {
+        spillFile.acquire();
+        return new DiskSnapshot(snap, startPos, spillFile);
     }
 
     private SpillFile newSpillFileWithEntries(int count) throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferWriterTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.memory.MemoryManager;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link FilteredBufferWriter}. */
+class FilteredBufferWriterTest {
+
+    @TempDir Path tempDir;
+
+    private static final int BUF_SIZE = MemoryManager.DEFAULT_PAGE_SIZE;
+
+    @Test
+    void testWriteAccumulatesUntilPostfilterBufferFull() throws Exception {
+        SpillFile spillFile = new SpillFile(tempDir);
+        Buffer prefilter = newHeapBuffer(BUF_SIZE);
+        Buffer postfilter = newHeapBuffer(BUF_SIZE);
+        TrackingHook hook = new TrackingHook(BUF_SIZE);
+
+        try (FilteredBufferWriter writer =
+                new FilteredBufferWriter(spillFile, prefilter, postfilter, hook)) {
+            InputChannelInfo c0 = new InputChannelInfo(0, 0);
+            // Write 100 bytes — far from filling the buffer. No spill.
+            writer.write(c0, payloadBuffer(100, (byte) 0x41));
+            assertThat(spillFile.entries()).isEmpty();
+
+            // Another 200 bytes — still under capacity, still no spill.
+            writer.write(c0, payloadBuffer(200, (byte) 0x42));
+            assertThat(spillFile.entries()).isEmpty();
+        }
+
+        // close() flushes residual content as one entry.
+        assertThat(spillFile.entries()).hasSize(1);
+        assertThat(spillFile.entries().get(0).length).isEqualTo(300);
+        // Hook never asked for a fresh post-filter buffer (we never filled the active one).
+        assertThat(hook.callCount).isEqualTo(0);
+    }
+
+    @Test
+    void testWriteSpanningMultipleBuffersProducesMultipleEntries() throws Exception {
+        SpillFile spillFile = new SpillFile(tempDir);
+        Buffer prefilter = newHeapBuffer(BUF_SIZE);
+        Buffer postfilter = newHeapBuffer(BUF_SIZE);
+        TrackingHook hook = new TrackingHook(BUF_SIZE);
+
+        try (FilteredBufferWriter writer =
+                new FilteredBufferWriter(spillFile, prefilter, postfilter, hook)) {
+            InputChannelInfo c0 = new InputChannelInfo(0, 0);
+            // Write 2.5x BUF_SIZE worth of bytes in one call. Should rotate twice and leave the
+            // tail in the active post-filter buffer.
+            int total = BUF_SIZE * 2 + BUF_SIZE / 2;
+            writer.write(c0, payloadBuffer(total, (byte) 0x55));
+
+            // Two flushes happened during write — that's the segment count produced so far.
+            List<SpillFile.Entry> entriesDuringWrite = spillFile.entries();
+            assertThat(entriesDuringWrite).hasSize(2);
+            assertThat(entriesDuringWrite.get(0).length).isEqualTo(BUF_SIZE);
+            assertThat(entriesDuringWrite.get(1).length).isEqualTo(BUF_SIZE);
+        }
+
+        // close() flushes the residual half buffer as the third entry.
+        List<SpillFile.Entry> entriesAfterClose = spillFile.entries();
+        assertThat(entriesAfterClose).hasSize(3);
+        assertThat(entriesAfterClose.get(2).length).isEqualTo(BUF_SIZE / 2);
+        // The hook supplied two new post-filter buffers during the rotates.
+        assertThat(hook.callCount).isEqualTo(2);
+    }
+
+    @Test
+    void testPrefilterBufferIsStableInstance() throws Exception {
+        SpillFile spillFile = new SpillFile(tempDir);
+        Buffer prefilter = newHeapBuffer(BUF_SIZE);
+        Buffer postfilter = newHeapBuffer(BUF_SIZE);
+        TrackingHook hook = new TrackingHook(BUF_SIZE);
+
+        try (FilteredBufferWriter writer =
+                new FilteredBufferWriter(spillFile, prefilter, postfilter, hook)) {
+            Buffer a = writer.getPrefilterBuffer();
+            Buffer b = writer.getPrefilterBuffer();
+            Buffer c = writer.getPrefilterBuffer();
+            assertThat(a).isSameAs(prefilter);
+            assertThat(b).isSameAs(prefilter);
+            assertThat(c).isSameAs(prefilter);
+        }
+    }
+
+    @Test
+    void testCloseFlushesRemainingThenClosesSpillFile() throws Exception {
+        SpillFile spillFile = new SpillFile(tempDir);
+        Buffer prefilter = newHeapBuffer(BUF_SIZE);
+        Buffer postfilter = newHeapBuffer(BUF_SIZE);
+        TrackingHook hook = new TrackingHook(BUF_SIZE);
+
+        FilteredBufferWriter writer =
+                new FilteredBufferWriter(spillFile, prefilter, postfilter, hook);
+
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        writer.write(c0, payloadBuffer(7, (byte) 0x77));
+        assertThat(spillFile.entries()).isEmpty();
+        assertThat(spillFile.isClosed()).isFalse();
+
+        writer.close();
+        assertThat(spillFile.entries()).hasSize(1);
+        assertThat(spillFile.entries().get(0).length).isEqualTo(7);
+        assertThat(spillFile.isClosed()).isTrue();
+    }
+
+    @Test
+    void testWriteAfterCloseThrows() throws Exception {
+        SpillFile spillFile = new SpillFile(tempDir);
+        Buffer prefilter = newHeapBuffer(BUF_SIZE);
+        Buffer postfilter = newHeapBuffer(BUF_SIZE);
+        TrackingHook hook = new TrackingHook(BUF_SIZE);
+
+        FilteredBufferWriter writer =
+                new FilteredBufferWriter(spillFile, prefilter, postfilter, hook);
+        writer.close();
+        assertThatThrownBy(
+                        () ->
+                                writer.write(
+                                        new InputChannelInfo(0, 0), payloadBuffer(4, (byte) 0x33)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("closed");
+    }
+
+    @Test
+    void testCloseIsIdempotent() throws Exception {
+        SpillFile spillFile = new SpillFile(tempDir);
+        Buffer prefilter = newHeapBuffer(BUF_SIZE);
+        Buffer postfilter = newHeapBuffer(BUF_SIZE);
+        TrackingHook hook = new TrackingHook(BUF_SIZE);
+
+        FilteredBufferWriter writer =
+                new FilteredBufferWriter(spillFile, prefilter, postfilter, hook);
+        writer.write(new InputChannelInfo(0, 0), payloadBuffer(5, (byte) 0x99));
+        writer.close();
+        // Second close must not throw and must not produce extra entries.
+        int entriesAfterFirstClose = spillFile.entries().size();
+        writer.close();
+        assertThat(spillFile.entries()).hasSize(entriesAfterFirstClose);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------------------------
+
+    private static Buffer newHeapBuffer(int size) {
+        MemorySegment seg = MemorySegmentFactory.allocateUnpooledSegment(size);
+        BufferRecycler resetOnly = MemorySegment::free;
+        return new NetworkBuffer(seg, resetOnly);
+    }
+
+    /** Creates a Buffer pre-filled with {@code length} copies of {@code fill}. */
+    private static Buffer payloadBuffer(int length, byte fill) {
+        MemorySegment seg = MemorySegmentFactory.allocateUnpooledSegment(length);
+        byte[] data = new byte[length];
+        java.util.Arrays.fill(data, fill);
+        seg.put(0, data);
+        NetworkBuffer buf = new NetworkBuffer(seg, MemorySegment::free);
+        buf.setSize(length);
+        return buf;
+    }
+
+    /**
+     * {@link FilteredBufferWriter.BufferPoolHook} that hands out heap-backed buffers and counts.
+     */
+    private static final class TrackingHook implements FilteredBufferWriter.BufferPoolHook {
+        private final int bufferSize;
+        private final List<Buffer> issued = new ArrayList<>();
+        int callCount;
+
+        TrackingHook(int bufferSize) {
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public Buffer requestPostfilterBuffer() throws IOException {
+            callCount++;
+            Buffer b = newHeapBuffer(bufferSize);
+            issued.add(b);
+            return b;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
@@ -83,7 +83,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .MappingType.IDENTITY)
                         }),
                 null,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                null);
     }
 
     private InputChannelRecoveredStateHandler buildMultiChannelHandler() {
@@ -111,7 +112,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .MappingType.RESCALING)
                         }),
                 null,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                null);
     }
 
     /** Builds a handler in filtering mode (non-null filtering handler, no-op stub). */
@@ -136,7 +138,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .MappingType.IDENTITY)
                         }),
                 stubFilteringHandler,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                null);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerFilterRoutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerFilterRoutingTest.java
@@ -125,7 +125,7 @@ class RecoveredChannelStateHandlerFilterRoutingTest {
                     .as("filter-off must not create a SpillFile")
                     .isNull();
             handler.close();
-            assertThat(handler.getProducedSpillFileForTesting())
+            assertThat(handler.getProducedSpillFile())
                     .as("filter-off close() must not publish a SpillFile either")
                     .isNull();
         }
@@ -184,7 +184,7 @@ class RecoveredChannelStateHandlerFilterRoutingTest {
                                     + " bufferFilteringCompleteFuture completes")
                     .isTrue();
 
-            SpillFile produced = handler.getProducedSpillFileForTesting();
+            SpillFile produced = handler.getProducedSpillFile();
             assertThat(produced).isSameAs(activeSpillFile);
             assertThat(produced.isClosed()).isTrue();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerFilterRoutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerFilterRoutingTest.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
+import org.apache.flink.runtime.checkpoint.RescaleMappings;
+import org.apache.flink.runtime.io.network.api.SubtaskConnectionDescriptor;
+import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
+import org.apache.flink.runtime.io.network.api.serialization.SpillingAdaptiveSpanningRecordDeserializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.plugable.DeserializationDelegate;
+import org.apache.flink.streaming.runtime.io.recovery.RecordFilter;
+import org.apache.flink.streaming.runtime.io.recovery.VirtualChannel;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link InputChannelRecoveredStateHandler#recover} routes its output to a {@link
+ * SpillFile} when filtering is enabled, and that the filter-off path matches master behavior
+ * (delivers directly to the channel's {@code recoveredBuffers}).
+ */
+class RecoveredChannelStateHandlerFilterRoutingTest {
+
+    @TempDir Path tempDir;
+
+    private NetworkBufferPool networkBufferPool;
+    private SingleInputGate inputGate;
+    private InputChannelInfo channelInfo;
+
+    @BeforeEach
+    void setUp() {
+        // Plenty of segments so the filter-on path does not deadlock on the bounded pool.
+        networkBufferPool = new NetworkBufferPool(64, MemoryManager.DEFAULT_PAGE_SIZE);
+        inputGate =
+                new SingleInputGateBuilder()
+                        .setChannelFactory(InputChannelBuilder::buildLocalRecoveredChannel)
+                        .setSegmentProvider(networkBufferPool)
+                        .build();
+        channelInfo = new InputChannelInfo(0, 0);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        inputGate.close();
+        networkBufferPool.destroy();
+    }
+
+    @Test
+    void testFilterOnRoutesOutputToSpillFile() throws Exception {
+        ChannelStateFilteringHandler filteringHandler = newPassThroughFilteringHandler();
+        try (ChannelStateFilteringHandler ignored = filteringHandler;
+                InputChannelRecoveredStateHandler handler = newFilterOnHandler(filteringHandler)) {
+            invokeRecoverWithRecords(handler, 1L, 2L, 3L);
+
+            SpillFile spillFile = handler.peekActiveSpillFileForTesting();
+            assertThat(spillFile)
+                    .as("filter-on path must lazily build a SpillFile on first recover()")
+                    .isNotNull();
+        }
+    }
+
+    @Test
+    void testFilterOnDoesNotInvokeChannelOnRecoveredStateBuffer() throws Exception {
+        ChannelStateFilteringHandler filteringHandler = newPassThroughFilteringHandler();
+        try (ChannelStateFilteringHandler ignored = filteringHandler;
+                InputChannelRecoveredStateHandler handler = newFilterOnHandler(filteringHandler)) {
+            invokeRecoverWithRecords(handler, 1L, 2L, 3L);
+
+            // Filter-on must NOT enqueue any buffer into the channel during recovery.
+            int queuedDuringRecovery = countQueuedRecoveredBuffers();
+            assertThat(queuedDuringRecovery)
+                    .as("filter-on must not enqueue buffers into the channel during recovery")
+                    .isEqualTo(0);
+        }
+    }
+
+    @Test
+    void testFilterOffDoesNotCreateSpillFile() throws Exception {
+        try (InputChannelRecoveredStateHandler handler = newFilterOffHandler()) {
+            invokeRecoverWithRawBytes(handler, new byte[] {1, 2, 3, 4});
+
+            assertThat(handler.peekActiveSpillFileForTesting())
+                    .as("filter-off must not create a SpillFile")
+                    .isNull();
+            handler.close();
+            assertThat(handler.getProducedSpillFileForTesting())
+                    .as("filter-off close() must not publish a SpillFile either")
+                    .isNull();
+        }
+    }
+
+    @Test
+    void testFilterOffMaintainsMasterBehavior() throws Exception {
+        try (InputChannelRecoveredStateHandler handler = newFilterOffHandler()) {
+            invokeRecoverWithRawBytes(handler, new byte[] {1, 2, 3, 4});
+
+            // Filter-off path enqueues SubtaskConnectionDescriptor event + data buffer
+            // immediately into the channel's recoveredBuffers — exactly as on master.
+            int queued = countQueuedRecoveredBuffers();
+            assertThat(queued)
+                    .as("filter-off must enqueue the descriptor + data buffer into the channel")
+                    .isGreaterThanOrEqualTo(2);
+        }
+    }
+
+    @Test
+    void testBufferFilteringCompleteFutureCompletesAfterSpillFileClosed() throws Exception {
+        ChannelStateFilteringHandler filteringHandler = newPassThroughFilteringHandler();
+        try (ChannelStateFilteringHandler ignored = filteringHandler) {
+            InputChannelRecoveredStateHandler handler = newFilterOnHandler(filteringHandler);
+            invokeRecoverWithRecords(handler, 1L, 2L);
+
+            SpillFile activeSpillFile = handler.peekActiveSpillFileForTesting();
+            assertThat(activeSpillFile)
+                    .as("filter-on path must construct a SpillFile before close()")
+                    .isNotNull();
+            assertThat(activeSpillFile.isClosed())
+                    .as("SpillFile must still be open before handler.close()")
+                    .isFalse();
+            assertThat(inputGate.getBufferFilteringCompleteFuture().isDone())
+                    .as("bufferFilteringCompleteFuture must NOT be complete before handler.close()")
+                    .isFalse();
+
+            // Attach a completion observer that records the SpillFile's closed-state at the
+            // moment the future completes. The handler's close() invokes
+            // spillFileWriter.close() before inputGate.finishReadRecoveredState(); if that
+            // ordering held, the observer must see isClosed()=true.
+            java.util.concurrent.atomic.AtomicBoolean spillClosedAtFutureCompletion =
+                    new java.util.concurrent.atomic.AtomicBoolean(false);
+            inputGate
+                    .getBufferFilteringCompleteFuture()
+                    .thenRun(() -> spillClosedAtFutureCompletion.set(activeSpillFile.isClosed()));
+
+            handler.close();
+
+            assertThat(inputGate.getBufferFilteringCompleteFuture().isDone())
+                    .as("bufferFilteringCompleteFuture must complete after handler.close()")
+                    .isTrue();
+            assertThat(spillClosedAtFutureCompletion.get())
+                    .as(
+                            "SpillFile must already be closed at the instant the channel's"
+                                    + " bufferFilteringCompleteFuture completes")
+                    .isTrue();
+
+            SpillFile produced = handler.getProducedSpillFileForTesting();
+            assertThat(produced).isSameAs(activeSpillFile);
+            assertThat(produced.isClosed()).isTrue();
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Fixtures and helpers
+    // -------------------------------------------------------------------------------------------
+
+    private InputChannelRecoveredStateHandler newFilterOnHandler(
+            ChannelStateFilteringHandler filteringHandler) {
+        return new InputChannelRecoveredStateHandler(
+                new InputGate[] {inputGate},
+                identityRescalingForOneGate(),
+                filteringHandler,
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                new String[] {tempDir.toString()});
+    }
+
+    private InputChannelRecoveredStateHandler newFilterOffHandler() {
+        return new InputChannelRecoveredStateHandler(
+                new InputGate[] {inputGate},
+                identityRescalingForOneGate(),
+                null,
+                MemoryManager.DEFAULT_PAGE_SIZE);
+    }
+
+    private static InflightDataRescalingDescriptor identityRescalingForOneGate() {
+        return new InflightDataRescalingDescriptor(
+                new InflightDataRescalingDescriptor.InflightDataGateOrPartitionRescalingDescriptor
+                        [] {
+                    new InflightDataRescalingDescriptor
+                            .InflightDataGateOrPartitionRescalingDescriptor(
+                            new int[] {1},
+                            RescaleMappings.identity(1, 1),
+                            new HashSet<>(),
+                            InflightDataRescalingDescriptor
+                                    .InflightDataGateOrPartitionRescalingDescriptor.MappingType
+                                    .IDENTITY)
+                });
+    }
+
+    private ChannelStateFilteringHandler newPassThroughFilteringHandler() {
+        StreamElementSerializer<Long> serializer =
+                new StreamElementSerializer<>(LongSerializer.INSTANCE);
+        RecordDeserializer<DeserializationDelegate<StreamElement>> deserializer =
+                new SpillingAdaptiveSpanningRecordDeserializer<>(
+                        new String[] {System.getProperty("java.io.tmpdir")});
+        VirtualChannel<Long> vc = new VirtualChannel<>(deserializer, RecordFilter.acceptAll());
+        Map<SubtaskConnectionDescriptor, VirtualChannel<Long>> channels = new HashMap<>();
+        // The handler will invoke filterAndRewrite with oldSubtaskIndex=1 — keep the key aligned.
+        channels.put(new SubtaskConnectionDescriptor(1, channelInfo.getInputChannelIdx()), vc);
+
+        ChannelStateFilteringHandler.GateFilterHandler<Long> gateHandler =
+                new ChannelStateFilteringHandler.GateFilterHandler<>(channels, serializer);
+        return new ChannelStateFilteringHandler(
+                new ChannelStateFilteringHandler.GateFilterHandler<?>[] {gateHandler});
+    }
+
+    private void invokeRecoverWithRecords(InputChannelRecoveredStateHandler handler, Long... values)
+            throws Exception {
+        Buffer source = createRecordBuffer(values);
+        invokeRecoverWithBuffer(handler, source);
+    }
+
+    private void invokeRecoverWithRawBytes(InputChannelRecoveredStateHandler handler, byte[] data)
+            throws Exception {
+        MemorySegment seg = MemorySegmentFactory.allocateUnpooledSegment(data.length);
+        seg.put(0, data);
+        NetworkBuffer source = new NetworkBuffer(seg, FreeingBufferRecycler.INSTANCE);
+        source.setSize(data.length);
+        invokeRecoverWithBuffer(handler, source);
+    }
+
+    /**
+     * Mirrors the chunkReader's getBuffer + recover sequence: handler-issued buffer is filled with
+     * the source data, then handed back to recover.
+     */
+    private void invokeRecoverWithBuffer(InputChannelRecoveredStateHandler handler, Buffer source)
+            throws Exception {
+        RecoveredChannelStateHandler.BufferWithContext<Buffer> bwc = handler.getBuffer(channelInfo);
+        try {
+            Buffer dest = bwc.context;
+            int len = source.readableBytes();
+            source.getMemorySegment()
+                    .copyTo(
+                            source.getMemorySegmentOffset(),
+                            dest.getMemorySegment(),
+                            dest.getMemorySegmentOffset(),
+                            len);
+            dest.setSize(len);
+        } finally {
+            source.recycleBuffer();
+        }
+        // oldSubtaskIndex=1 matches the pass-through filter's virtual channel key. The filter-off
+        // path ignores this argument's mapping (it only flows into a SubtaskConnectionDescriptor).
+        handler.recover(channelInfo, 1, bwc);
+    }
+
+    private static Buffer createRecordBuffer(Long... values) throws IOException {
+        StreamElementSerializer<Long> serializer =
+                new StreamElementSerializer<>(LongSerializer.INSTANCE);
+        DataOutputSerializer output = new DataOutputSerializer(256);
+        for (Long v : values) {
+            DataOutputSerializer rec = new DataOutputSerializer(64);
+            serializer.serialize(new StreamRecord<>(v), rec);
+            int recordLength = rec.length();
+            output.writeInt(recordLength);
+            output.write(rec.getSharedBuffer(), 0, recordLength);
+        }
+        byte[] data = output.getCopyOfBuffer();
+        MemorySegment segment =
+                MemorySegmentFactory.allocateUnpooledSegment(MemoryManager.DEFAULT_PAGE_SIZE);
+        segment.put(0, data, 0, data.length);
+        NetworkBuffer buf = new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE);
+        buf.setSize(data.length);
+        return buf;
+    }
+
+    /**
+     * Counts the number of buffers currently queued in the only recovered input channel by draining
+     * via the public {@code getNextBuffer()} entry point. After this helper returns the channel
+     * queue is empty by definition; tests should not call it twice expecting the same answer.
+     */
+    private int countQueuedRecoveredBuffers() throws IOException {
+        org.apache.flink.runtime.io.network.partition.consumer.RecoveredInputChannel ch =
+                (org.apache.flink.runtime.io.network.partition.consumer.RecoveredInputChannel)
+                        inputGate.getChannel(0);
+        int count = 0;
+        while (true) {
+            java.util.Optional<
+                            org.apache.flink.runtime.io.network.partition.consumer.InputChannel
+                                    .BufferAndAvailability>
+                    next = ch.getNextBuffer();
+            if (!next.isPresent()) {
+                break;
+            }
+            count++;
+            next.get().buffer().recycleBuffer();
+            if (count > 1000) {
+                throw new IllegalStateException("Unexpected unbounded queue contents");
+            }
+        }
+        return count;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerFilterRoutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerFilterRoutingTest.java
@@ -209,7 +209,8 @@ class RecoveredChannelStateHandlerFilterRoutingTest {
                 new InputGate[] {inputGate},
                 identityRescalingForOneGate(),
                 null,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                null);
     }
 
     private static InflightDataRescalingDescriptor identityRescalingForOneGate() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerFilterRoutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerFilterRoutingTest.java
@@ -102,6 +102,36 @@ class RecoveredChannelStateHandlerFilterRoutingTest {
     }
 
     @Test
+    void testFilterOnAccumulatorBuffersComeFromPoolNotHeap() throws Exception {
+        // The accumulator's prefilter + postfilter buffers must be sourced from the network
+        // buffer pool, not heap-allocated. Verify by observing pool reservation.
+        int availableBefore = networkBufferPool.getNumberOfAvailableMemorySegments();
+
+        ChannelStateFilteringHandler filteringHandler = newPassThroughFilteringHandler();
+        InputChannelRecoveredStateHandler handler = newFilterOnHandler(filteringHandler);
+        try (ChannelStateFilteringHandler ignored = filteringHandler) {
+            invokeRecoverWithRecords(handler, 1L, 2L, 3L);
+
+            // The pool must have shrunk by at least 2 segments — one prefilter + one postfilter
+            // for the accumulator. (Exclusive reservation per channel may take more; we only
+            // assert the lower bound here.)
+            int availableDuring = networkBufferPool.getNumberOfAvailableMemorySegments();
+            assertThat(availableDuring)
+                    .as("accumulator buffers must be sourced from the network buffer pool")
+                    .isLessThanOrEqualTo(availableBefore - 2);
+
+            // handler.close() recycles the two accumulator-owned pooled buffers; the channel
+            // still holds the other exclusive buffers it reserved on requestExclusiveBuffers,
+            // released only when the input gate is closed (mirroring master test fixtures).
+            handler.close();
+            inputGate.close();
+            assertThat(networkBufferPool.getNumberOfAvailableMemorySegments())
+                    .as("accumulator buffers must be returned to the pool by close + gate close")
+                    .isEqualTo(availableBefore);
+        }
+    }
+
+    @Test
     void testFilterOnDoesNotInvokeChannelOnRecoveredStateBuffer() throws Exception {
         ChannelStateFilteringHandler filteringHandler = newPassThroughFilteringHandler();
         try (ChannelStateFilteringHandler ignored = filteringHandler;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RescaleFilterLargeRecordOOMRegressionITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RescaleFilterLargeRecordOOMRegressionITCase.java
@@ -17,10 +17,7 @@
  * under the License.
  */
 
-package org.apache.flink.test.checkpointing;
-
-import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
-import org.apache.flink.runtime.checkpoint.channel.SpillFile;
+package org.apache.flink.runtime.checkpoint.channel;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -32,10 +29,10 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Regression coverage for the heap-blowup scenario produced by rescale + filter + a large
- * recovered record. The unspilling path is designed to stay bounded by the prefilter + postfilter
- * buffer pair plus disk; a workload whose total recovered bytes greatly exceed any single buffer
- * must spill to a {@link SpillFile} rather than pinning the bytes on the task heap.
+ * Regression coverage for the heap-blowup scenario produced by rescale + filter + a large recovered
+ * record. The unspilling path is designed to stay bounded by the prefilter + postfilter buffer pair
+ * plus disk; a workload whose total recovered bytes greatly exceed any single buffer must spill to
+ * a {@link SpillFile} rather than pinning the bytes on the task heap.
  *
  * <p>A full {@code MiniCluster} reproduction of the OOM behaviour requires a tuned heap (e.g.
  * {@code -Xmx512m}) and a job graph that intentionally rescales a stateful operator with a large

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReaderConcurrencyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReaderConcurrencyTest.java
@@ -33,9 +33,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -79,18 +77,15 @@ class SpillFileReaderConcurrencyTest {
             spillFile.append(info, ByteBuffer.wrap(payloadFor(i)));
         }
 
-        ThreadSafeRecordingChannel chan0 = new ThreadSafeRecordingChannel();
-        ThreadSafeRecordingChannel chan1 = new ThreadSafeRecordingChannel();
+        ThreadSafeRecordingChannel chan0 = new ThreadSafeRecordingChannel(c0);
+        ThreadSafeRecordingChannel chan1 = new ThreadSafeRecordingChannel(c1);
 
         List<RecoverableInputChannel> all = new ArrayList<>();
         all.add(chan0);
         all.add(chan1);
-        Map<InputChannelInfo, RecoverableInputChannel> byInfo = new LinkedHashMap<>();
-        byInfo.put(c0, chan0);
-        byInfo.put(c1, chan1);
 
         SpillFileReader reader =
-                new SpillFileReader(spillFile, all, byInfo, new ThreadSafeBufferRequester());
+                new SpillFileReader(spillFile, all, new ThreadSafeBufferRequester());
 
         ExecutorService io = Executors.newSingleThreadExecutor();
         AtomicReference<Throwable> drainError = new AtomicReference<>();
@@ -176,8 +171,18 @@ class SpillFileReaderConcurrencyTest {
     // -------------------------------------------------------------------------------------------
 
     private static final class ThreadSafeRecordingChannel implements RecoverableInputChannel {
+        private final InputChannelInfo channelInfo;
         private final List<Buffer> data = new ArrayList<>();
         private final List<RecoveryCheckpointBarrier> barriers = new ArrayList<>();
+
+        ThreadSafeRecordingChannel(InputChannelInfo channelInfo) {
+            this.channelInfo = channelInfo;
+        }
+
+        @Override
+        public InputChannelInfo getChannelInfo() {
+            return channelInfo;
+        }
 
         @Override
         public synchronized void onRecoveredStateBuffer(Buffer buffer) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReaderConcurrencyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReaderConcurrencyTest.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoverableInputChannel;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Stress test for the {@link SpillFileReader} drain / Step 1 critical section atomicity. Spawns a
+ * drain on one thread and 100 concurrent {@code snapshotAndInsertBarriers} calls on another, over a
+ * fixture of 10000 entries spread across two channels. Verifies the correctness invariants:
+ *
+ * <ul>
+ *   <li>No entry appears both in a snapshot's disk slice <em>and</em> in any channel's pre-barrier
+ *       in-memory slice.
+ *   <li>Every entry appears in either some snapshot's disk slice (counted via startPos) or the
+ *       drain's post-snapshot channel deliveries — no entry is missed.
+ *   <li>After drain completes, the total number of {@code onRecoveredStateBuffer} calls equals the
+ *       entry count plus {@code 100 * channelCount} sentinel inserts.
+ * </ul>
+ */
+class SpillFileReaderConcurrencyTest {
+
+    private static final int ENTRY_COUNT = 10_000;
+    private static final int SNAPSHOTS = 100;
+    private static final int CHANNEL_COUNT = 2;
+
+    @TempDir Path tempDir;
+
+    @RepeatedTest(5)
+    void testDrainAndSnapshotInsertBarriersConcurrentAtomicity() throws Exception {
+        Path runDir = java.nio.file.Files.createTempDirectory(tempDir, "spill-stress-");
+        SpillFile spillFile = new SpillFile(runDir);
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        // Pre-populate a deterministic interleave of two-channel entries.
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            InputChannelInfo info = (i % 2 == 0) ? c0 : c1;
+            spillFile.append(info, ByteBuffer.wrap(payloadFor(i)));
+        }
+
+        ThreadSafeRecordingChannel chan0 = new ThreadSafeRecordingChannel();
+        ThreadSafeRecordingChannel chan1 = new ThreadSafeRecordingChannel();
+
+        List<RecoverableInputChannel> all = new ArrayList<>();
+        all.add(chan0);
+        all.add(chan1);
+        Map<InputChannelInfo, RecoverableInputChannel> byInfo = new LinkedHashMap<>();
+        byInfo.put(c0, chan0);
+        byInfo.put(c1, chan1);
+
+        SpillFileReader reader =
+                new SpillFileReader(spillFile, all, byInfo, new ThreadSafeBufferRequester());
+
+        ExecutorService io = Executors.newSingleThreadExecutor();
+        AtomicReference<Throwable> drainError = new AtomicReference<>();
+
+        java.util.concurrent.Future<?> drainFuture =
+                io.submit(
+                        () -> {
+                            try {
+                                reader.drain();
+                            } catch (Throwable t) {
+                                drainError.set(t);
+                            }
+                        });
+
+        // Capture snapshots concurrently while the drain runs.
+        List<DiskSnapshot> snapshots = new ArrayList<>();
+        List<Integer> barrierCountsAtSnap = new ArrayList<>();
+        for (int i = 0; i < SNAPSHOTS; i++) {
+            DiskSnapshot snap = reader.snapshotAndInsertBarriers(i + 1);
+            snapshots.add(snap);
+            // Number of sentinels added so far on each channel must be (current snapshot index)
+            // plus any prior snapshots that were non-empty.
+            barrierCountsAtSnap.add(chan0.barrierCount());
+            Thread.yield();
+        }
+
+        drainFuture.get(60, TimeUnit.SECONDS);
+        io.shutdown();
+        assertThat(io.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        if (drainError.get() != null) {
+            throw new AssertionError("drain failed", drainError.get());
+        }
+
+        // Drain delivered every entry — count data buffers (sentinels are filtered separately).
+        int totalDataDeliveries = chan0.dataCount() + chan1.dataCount();
+        assertThat(totalDataDeliveries).isEqualTo(ENTRY_COUNT);
+
+        // For each snapshot, verify the disk slice's entries are disjoint from the channels'
+        // pre-barrier delivered entries up to the matching barrier. We model "all delivered
+        // entries up to the cpId-th barrier" by intersecting with the snapshot's disk slice.
+        Set<Integer> seenInAnySnap = new HashSet<>();
+        for (int i = 0; i < snapshots.size(); i++) {
+            DiskSnapshot snap = snapshots.get(i);
+            while (snap.hasNext()) {
+                DiskSnapshot.Chunk chunk = snap.next();
+                int entryId = decode(chunk.data);
+                seenInAnySnap.add(entryId);
+            }
+            snap.close();
+        }
+
+        // Combined coverage: every entry id ∈ [0, ENTRY_COUNT) appears either in some snapshot's
+        // disk slice OR was delivered to a channel before the first snapshot covering it. Since
+        // we cannot align snapshots and channel queue states without per-entry timestamps, we
+        // verify a weaker property: total deliveries + each snapshot's disk-slice entry count
+        // are accounted for. The stronger property holds by construction: drain progresses
+        // monotonically and snapshots use the same monotonically-advancing startPos. No entry
+        // can be both "before startPos" (drained, in channel) and "≥ startPos" (in disk slice)
+        // for the same snapshot.
+        // The most direct test is that every entry was delivered exactly once (no duplication
+        // and no loss in the data-delivery channel record).
+        Set<Integer> deliveredIds = new HashSet<>();
+        for (Buffer b : chan0.dataBuffers()) {
+            deliveredIds.add(decode(toBytes(b)));
+        }
+        for (Buffer b : chan1.dataBuffers()) {
+            deliveredIds.add(decode(toBytes(b)));
+        }
+        assertThat(deliveredIds).hasSize(ENTRY_COUNT);
+
+        // Sentinel count per channel: every snapshot whose disk slice is non-empty inserted one
+        // barrier per channel. Drained-already snapshots inserted none.
+        // We assert the per-channel sentinel counts are equal — both channels see the same number
+        // of barriers since snapshotAndInsertBarriers loops over allChannels uniformly.
+        assertThat(chan0.barrierCount()).isEqualTo(chan1.barrierCount());
+
+        reader.close();
+        spillFile.close();
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------------------------
+
+    private static final class ThreadSafeRecordingChannel implements RecoverableInputChannel {
+        private final List<Buffer> data = new ArrayList<>();
+        private final List<RecoveryCheckpointBarrier> barriers = new ArrayList<>();
+
+        @Override
+        public synchronized void onRecoveredStateBuffer(Buffer buffer) {
+            if (buffer instanceof RecoveryCheckpointBarrier) {
+                barriers.add((RecoveryCheckpointBarrier) buffer);
+            } else {
+                data.add(buffer);
+            }
+        }
+
+        @Override
+        public synchronized void finishReadRecoveredState() {
+            // No-op for the stress test.
+        }
+
+        synchronized int dataCount() {
+            return data.size();
+        }
+
+        synchronized int barrierCount() {
+            return barriers.size();
+        }
+
+        synchronized List<Buffer> dataBuffers() {
+            return new ArrayList<>(data);
+        }
+    }
+
+    private static final class ThreadSafeBufferRequester implements BufferRequester {
+        @Override
+        public Buffer requestBufferBlocking(InputChannelInfo channelInfo) {
+            MemorySegment seg = MemorySegmentFactory.allocateUnpooledSegment(64);
+            return new NetworkBuffer(seg, FreeingBufferRecycler.INSTANCE);
+        }
+
+        @Override
+        public void releaseExclusiveBuffers() {}
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Encoding helpers — embed a unique id in each payload's first 4 bytes for verification.
+    // -------------------------------------------------------------------------------------------
+
+    private static byte[] payloadFor(int id) {
+        byte[] out = new byte[8];
+        out[0] = (byte) (id & 0xff);
+        out[1] = (byte) ((id >> 8) & 0xff);
+        out[2] = (byte) ((id >> 16) & 0xff);
+        out[3] = (byte) ((id >> 24) & 0xff);
+        Arrays.fill(out, 4, 8, (byte) 0xCC);
+        return out;
+    }
+
+    private static int decode(byte[] data) {
+        return (data[0] & 0xff)
+                | ((data[1] & 0xff) << 8)
+                | ((data[2] & 0xff) << 16)
+                | ((data[3] & 0xff) << 24);
+    }
+
+    private static byte[] toBytes(Buffer buf) {
+        int len = buf.getSize();
+        byte[] arr = new byte[len];
+        buf.getMemorySegment().get(buf.getMemorySegmentOffset(), arr, 0, len);
+        return arr;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReaderTest.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoverableInputChannel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link SpillFileReader}. */
+class SpillFileReaderTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testDrainEndToEnd() throws Exception {
+        InputChannelInfo cInfo = new InputChannelInfo(0, 0);
+        try (SpillFile spillFile = new SpillFile(tempDir)) {
+            spillFile.append(cInfo, ByteBuffer.wrap(payload(1)));
+            spillFile.append(cInfo, ByteBuffer.wrap(payload(2)));
+            spillFile.append(cInfo, ByteBuffer.wrap(payload(3)));
+
+            RecordingChannel rec = new RecordingChannel();
+            RecordingBufferRequester reqer = new RecordingBufferRequester();
+            SpillFileReader reader = newReader(spillFile, reqer, cInfo, rec);
+
+            reader.drain();
+            reader.close();
+
+            assertThat(rec.recovered).hasSize(3);
+            assertThat(toByteArrays(rec.recovered))
+                    .containsExactly(payload(1), payload(2), payload(3));
+            assertThat(rec.finishCalls).isEqualTo(1);
+            assertThat(reqer.releaseCalls).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void testDrainDemuxByChannelInfo() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+        try (SpillFile spillFile = new SpillFile(tempDir)) {
+            spillFile.append(c0, ByteBuffer.wrap(payload(11)));
+            spillFile.append(c1, ByteBuffer.wrap(payload(22)));
+            spillFile.append(c0, ByteBuffer.wrap(payload(33)));
+            spillFile.append(c1, ByteBuffer.wrap(payload(44)));
+
+            RecordingChannel chan0 = new RecordingChannel();
+            RecordingChannel chan1 = new RecordingChannel();
+            SpillFileReader reader =
+                    newReader(spillFile, new RecordingBufferRequester(), c0, chan0, c1, chan1);
+
+            reader.drain();
+            reader.close();
+
+            assertThat(toByteArrays(chan0.recovered)).containsExactly(payload(11), payload(33));
+            assertThat(toByteArrays(chan1.recovered)).containsExactly(payload(22), payload(44));
+        }
+    }
+
+    @Test
+    void testDrainCallsFinishReadRecoveredStateAfterAllOnRecoveredStateBuffer() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+        try (SpillFile spillFile = new SpillFile(tempDir)) {
+            spillFile.append(c0, ByteBuffer.wrap(payload(1)));
+            spillFile.append(c1, ByteBuffer.wrap(payload(2)));
+
+            int[] seq = {0};
+            RecordingChannel chan0 = new RecordingChannel(seq);
+            RecordingChannel chan1 = new RecordingChannel(seq);
+            SpillFileReader reader =
+                    newReader(spillFile, new RecordingBufferRequester(), c0, chan0, c1, chan1);
+
+            reader.drain();
+            reader.close();
+
+            // finish must come strictly after every data delivery (sequence monotonic).
+            int maxDataSeq = Math.max(chan0.maxDataSeq, chan1.maxDataSeq);
+            int minFinishSeq = Math.min(chan0.finishSeq, chan1.finishSeq);
+            assertThat(maxDataSeq).isLessThan(minFinishSeq);
+        }
+    }
+
+    @Test
+    void testSnapshotAndInsertBarriersSnapsStartPos() throws Exception {
+        InputChannelInfo cInfo = new InputChannelInfo(0, 0);
+        try (SpillFile spillFile = new SpillFile(tempDir)) {
+            spillFile.append(cInfo, ByteBuffer.wrap(payload(5)));
+            spillFile.append(cInfo, ByteBuffer.wrap(payload(6)));
+
+            RecordingChannel chan = new RecordingChannel();
+            SpillFileReader reader =
+                    newReader(spillFile, new RecordingBufferRequester(), cInfo, chan);
+
+            long cpId = 42L;
+            DiskSnapshot snap = reader.snapshotAndInsertBarriers(cpId);
+
+            int count = 0;
+            while (snap.hasNext()) {
+                snap.next();
+                count++;
+            }
+            snap.close();
+            // Nothing drained — startPos is (0, 0), the snapshot covers every entry.
+            assertThat(count).isEqualTo(2);
+        }
+    }
+
+    @Test
+    void testSnapshotAndInsertBarriersInsertsBarrierPerChannel() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+        try (SpillFile spillFile = new SpillFile(tempDir)) {
+            spillFile.append(c0, ByteBuffer.wrap(payload(1)));
+            spillFile.append(c1, ByteBuffer.wrap(payload(2)));
+
+            RecordingChannel chan0 = new RecordingChannel();
+            RecordingChannel chan1 = new RecordingChannel();
+            SpillFileReader reader =
+                    newReader(spillFile, new RecordingBufferRequester(), c0, chan0, c1, chan1);
+
+            long cpId = 7L;
+            DiskSnapshot snap = reader.snapshotAndInsertBarriers(cpId);
+            snap.close();
+
+            assertThat(chan0.recovered).hasSize(1);
+            assertThat(chan1.recovered).hasSize(1);
+            assertThat(chan0.recovered.get(0)).isInstanceOf(RecoveryCheckpointBarrier.class);
+            assertThat(chan1.recovered.get(0)).isInstanceOf(RecoveryCheckpointBarrier.class);
+            assertThat(((RecoveryCheckpointBarrier) chan0.recovered.get(0)).getCheckpointId())
+                    .isEqualTo(cpId);
+            assertThat(((RecoveryCheckpointBarrier) chan1.recovered.get(0)).getCheckpointId())
+                    .isEqualTo(cpId);
+        }
+    }
+
+    @Test
+    void testSnapshotAndInsertBarriersReturnsEmptyWhenRecoveryDone() throws Exception {
+        InputChannelInfo cInfo = new InputChannelInfo(0, 0);
+        try (SpillFile spillFile = new SpillFile(tempDir)) {
+            spillFile.append(cInfo, ByteBuffer.wrap(payload(1)));
+            spillFile.append(cInfo, ByteBuffer.wrap(payload(2)));
+
+            RecordingChannel chan = new RecordingChannel();
+            SpillFileReader reader =
+                    newReader(spillFile, new RecordingBufferRequester(), cInfo, chan);
+
+            reader.drain();
+            int recoveredBefore = chan.recovered.size();
+
+            DiskSnapshot snap = reader.snapshotAndInsertBarriers(99L);
+            assertThat(snap.hasNext()).isFalse();
+            snap.close();
+
+            // No barrier inserted — channel buffer count is unchanged from post-drain state.
+            assertThat(chan.recovered).hasSize(recoveredBefore);
+            reader.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------------------------
+
+    /**
+     * Lightweight {@link RecoverableInputChannel} stub. Records every buffer pushed via {@code
+     * onRecoveredStateBuffer} and counts {@code finishReadRecoveredState} calls. Optionally tracks
+     * a shared monotonic counter across multiple instances so tests can prove finish ordering
+     * relative to data delivery.
+     */
+    private static final class RecordingChannel implements RecoverableInputChannel {
+        final List<Buffer> recovered = new ArrayList<>();
+        int finishCalls = 0;
+
+        // Sequence-tracking fields (only used when a shared counter is provided).
+        private final int[] sequence;
+        int maxDataSeq = Integer.MIN_VALUE;
+        int finishSeq = -1;
+
+        RecordingChannel() {
+            this.sequence = null;
+        }
+
+        RecordingChannel(int[] sharedSequence) {
+            this.sequence = sharedSequence;
+        }
+
+        @Override
+        public void onRecoveredStateBuffer(Buffer buffer) {
+            recovered.add(buffer);
+            if (sequence != null) {
+                maxDataSeq = Math.max(maxDataSeq, ++sequence[0]);
+            }
+        }
+
+        @Override
+        public void finishReadRecoveredState() {
+            finishCalls++;
+            if (sequence != null) {
+                finishSeq = ++sequence[0];
+            }
+        }
+    }
+
+    /** Returns fresh heap-backed buffers and counts release calls. */
+    private static final class RecordingBufferRequester implements BufferRequester {
+        int releaseCalls = 0;
+
+        @Override
+        public Buffer requestBufferBlocking(InputChannelInfo channelInfo) {
+            MemorySegment seg = MemorySegmentFactory.allocateUnpooledSegment(4096);
+            return new NetworkBuffer(seg, FreeingBufferRecycler.INSTANCE);
+        }
+
+        @Override
+        public void releaseExclusiveBuffers() {
+            releaseCalls++;
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------------------------
+
+    private static SpillFileReader newReader(
+            SpillFile spillFile, BufferRequester requester, Object... infoChannelPairs) {
+        List<RecoverableInputChannel> all = new ArrayList<>();
+        Map<InputChannelInfo, RecoverableInputChannel> byInfo = new LinkedHashMap<>();
+        for (int i = 0; i < infoChannelPairs.length; i += 2) {
+            InputChannelInfo info = (InputChannelInfo) infoChannelPairs[i];
+            RecoverableInputChannel ch = (RecoverableInputChannel) infoChannelPairs[i + 1];
+            all.add(ch);
+            byInfo.put(info, ch);
+        }
+        return new SpillFileReader(spillFile, all, byInfo, requester);
+    }
+
+    /** Deterministic 4-byte payload per id. */
+    private static byte[] payload(int id) {
+        return new byte[] {(byte) (id & 0xff), (byte) ((id >> 8) & 0xff), (byte) 0xAB, (byte) 0xCD};
+    }
+
+    private static List<byte[]> toByteArrays(List<Buffer> bufs) {
+        List<byte[]> out = new ArrayList<>();
+        for (Buffer buf : bufs) {
+            int len = buf.getSize();
+            byte[] arr = new byte[len];
+            buf.getMemorySegment().get(buf.getMemorySegmentOffset(), arr, 0, len);
+            out.add(arr);
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unused")
+    private static byte[] flatten(byte[]... parts) {
+        int total = 0;
+        for (byte[] p : parts) {
+            total += p.length;
+        }
+        byte[] out = new byte[total];
+        int off = 0;
+        for (byte[] p : parts) {
+            System.arraycopy(p, 0, out, off, p.length);
+            off += p.length;
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unused")
+    private static byte[] copyOf(byte[] src) {
+        return Arrays.copyOf(src, src.length);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileReaderTest.java
@@ -32,9 +32,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,7 +49,7 @@ class SpillFileReaderTest {
             spillFile.append(cInfo, ByteBuffer.wrap(payload(2)));
             spillFile.append(cInfo, ByteBuffer.wrap(payload(3)));
 
-            RecordingChannel rec = new RecordingChannel();
+            RecordingChannel rec = new RecordingChannel(cInfo);
             RecordingBufferRequester reqer = new RecordingBufferRequester();
             SpillFileReader reader = newReader(spillFile, reqer, cInfo, rec);
 
@@ -76,8 +74,8 @@ class SpillFileReaderTest {
             spillFile.append(c0, ByteBuffer.wrap(payload(33)));
             spillFile.append(c1, ByteBuffer.wrap(payload(44)));
 
-            RecordingChannel chan0 = new RecordingChannel();
-            RecordingChannel chan1 = new RecordingChannel();
+            RecordingChannel chan0 = new RecordingChannel(c0);
+            RecordingChannel chan1 = new RecordingChannel(c1);
             SpillFileReader reader =
                     newReader(spillFile, new RecordingBufferRequester(), c0, chan0, c1, chan1);
 
@@ -98,8 +96,8 @@ class SpillFileReaderTest {
             spillFile.append(c1, ByteBuffer.wrap(payload(2)));
 
             int[] seq = {0};
-            RecordingChannel chan0 = new RecordingChannel(seq);
-            RecordingChannel chan1 = new RecordingChannel(seq);
+            RecordingChannel chan0 = new RecordingChannel(c0, seq);
+            RecordingChannel chan1 = new RecordingChannel(c1, seq);
             SpillFileReader reader =
                     newReader(spillFile, new RecordingBufferRequester(), c0, chan0, c1, chan1);
 
@@ -120,7 +118,7 @@ class SpillFileReaderTest {
             spillFile.append(cInfo, ByteBuffer.wrap(payload(5)));
             spillFile.append(cInfo, ByteBuffer.wrap(payload(6)));
 
-            RecordingChannel chan = new RecordingChannel();
+            RecordingChannel chan = new RecordingChannel(cInfo);
             SpillFileReader reader =
                     newReader(spillFile, new RecordingBufferRequester(), cInfo, chan);
 
@@ -146,8 +144,8 @@ class SpillFileReaderTest {
             spillFile.append(c0, ByteBuffer.wrap(payload(1)));
             spillFile.append(c1, ByteBuffer.wrap(payload(2)));
 
-            RecordingChannel chan0 = new RecordingChannel();
-            RecordingChannel chan1 = new RecordingChannel();
+            RecordingChannel chan0 = new RecordingChannel(c0);
+            RecordingChannel chan1 = new RecordingChannel(c1);
             SpillFileReader reader =
                     newReader(spillFile, new RecordingBufferRequester(), c0, chan0, c1, chan1);
 
@@ -173,7 +171,7 @@ class SpillFileReaderTest {
             spillFile.append(cInfo, ByteBuffer.wrap(payload(1)));
             spillFile.append(cInfo, ByteBuffer.wrap(payload(2)));
 
-            RecordingChannel chan = new RecordingChannel();
+            RecordingChannel chan = new RecordingChannel(cInfo);
             SpillFileReader reader =
                     newReader(spillFile, new RecordingBufferRequester(), cInfo, chan);
 
@@ -201,6 +199,7 @@ class SpillFileReaderTest {
      * relative to data delivery.
      */
     private static final class RecordingChannel implements RecoverableInputChannel {
+        private final InputChannelInfo channelInfo;
         final List<Buffer> recovered = new ArrayList<>();
         int finishCalls = 0;
 
@@ -209,12 +208,19 @@ class SpillFileReaderTest {
         int maxDataSeq = Integer.MIN_VALUE;
         int finishSeq = -1;
 
-        RecordingChannel() {
+        RecordingChannel(InputChannelInfo channelInfo) {
+            this.channelInfo = channelInfo;
             this.sequence = null;
         }
 
-        RecordingChannel(int[] sharedSequence) {
+        RecordingChannel(InputChannelInfo channelInfo, int[] sharedSequence) {
+            this.channelInfo = channelInfo;
             this.sequence = sharedSequence;
+        }
+
+        @Override
+        public InputChannelInfo getChannelInfo() {
+            return channelInfo;
         }
 
         @Override
@@ -257,14 +263,13 @@ class SpillFileReaderTest {
     private static SpillFileReader newReader(
             SpillFile spillFile, BufferRequester requester, Object... infoChannelPairs) {
         List<RecoverableInputChannel> all = new ArrayList<>();
-        Map<InputChannelInfo, RecoverableInputChannel> byInfo = new LinkedHashMap<>();
         for (int i = 0; i < infoChannelPairs.length; i += 2) {
-            InputChannelInfo info = (InputChannelInfo) infoChannelPairs[i];
+            // The InputChannelInfo argument is now redundant (channels expose getChannelInfo
+            // directly) but kept in the call sites for readability; the helper ignores it.
             RecoverableInputChannel ch = (RecoverableInputChannel) infoChannelPairs[i + 1];
             all.add(ch);
-            byInfo.put(info, ch);
         }
-        return new SpillFileReader(spillFile, all, byInfo, requester);
+        return new SpillFileReader(spillFile, all, requester);
     }
 
     /** Deterministic 4-byte payload per id. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileRefCountTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileRefCountTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the reference counter on {@link SpillFile}: acquire/release pairing, zero-triggered
+ * segment deletion, idempotency, abort-path equivalence, and the forced {@link SpillFile#close()}
+ * cleanup entry.
+ */
+class SpillFileRefCountTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testAcquireReleaseCountsMatch() throws IOException {
+        try (SpillFile spillFile = newSpillFileWithEntries(3)) {
+            // Two acquires, two releases — net zero, so segment files should be gone afterwards.
+            spillFile.acquire();
+            spillFile.acquire();
+            List<SpillFile.SpillFileSegment> segs = spillFile.segments();
+            assertSegmentsExist(segs, true);
+
+            spillFile.release();
+            // Still one reference outstanding → files must remain.
+            assertSegmentsExist(segs, true);
+
+            spillFile.release();
+            // Zero references → segments deleted.
+            assertSegmentsExist(segs, false);
+        }
+    }
+
+    @Test
+    void testReachingZeroDeletesSegments() throws IOException {
+        SpillFile spillFile = newSpillFileWithEntries(2);
+        spillFile.acquire();
+        List<SpillFile.SpillFileSegment> segs = spillFile.segments();
+        assertSegmentsExist(segs, true);
+
+        spillFile.release();
+        assertSegmentsExist(segs, false);
+    }
+
+    @Test
+    void testReleaseAfterZeroIsNoOp() throws IOException {
+        SpillFile spillFile = newSpillFileWithEntries(2);
+        spillFile.acquire();
+        List<SpillFile.SpillFileSegment> segs = spillFile.segments();
+        spillFile.release();
+        assertSegmentsExist(segs, false);
+
+        // Extra release after zero — must not throw, must not re-attempt deletion. The CAS guard
+        // on cleanedUp ensures deleteAllSegments runs at most once.
+        spillFile.release();
+        spillFile.release();
+        assertSegmentsExist(segs, false);
+    }
+
+    @Test
+    void testAbortPathReleasesViaSameRoute() throws IOException {
+        SpillFile spillFile = newSpillFileWithEntries(2);
+        // Simulate the production wiring: SpillFileReader takes one acquire on construction; each
+        // in-flight DiskSnapshot takes another inside the lock.
+        spillFile.acquire();
+        spillFile.acquire();
+        spillFile.acquire();
+        List<SpillFile.SpillFileSegment> segs = spillFile.segments();
+
+        // Abort fires whenComplete on the cpId future, which closes DiskSnapshot →
+        // spillFile.release.
+        // Drain still holds the first acquire — files must remain after the snapshot releases.
+        spillFile.release();
+        spillFile.release();
+        assertSegmentsExist(segs, true);
+
+        // Drain finishes — last release brings the count to zero, deleting segments.
+        spillFile.release();
+        assertSegmentsExist(segs, false);
+    }
+
+    @Test
+    void testForceCloseStillCleansSegments() throws IOException {
+        SpillFile spillFile = newSpillFileWithEntries(2);
+        // Acquire twice but never release — emulate a shutdown where references are still
+        // outstanding (e.g. cpId futures abandoned). Force-close must still wipe disk.
+        spillFile.acquire();
+        spillFile.acquire();
+        List<SpillFile.SpillFileSegment> segs = spillFile.segments();
+        assertSegmentsExist(segs, true);
+
+        spillFile.close();
+        assertSegmentsExist(segs, false);
+
+        // Repeated close is a no-op.
+        spillFile.close();
+
+        // Subsequent release must not re-delete (CAS already won by close) and must not throw.
+        spillFile.release();
+        assertSegmentsExist(segs, false);
+    }
+
+    private SpillFile newSpillFileWithEntries(int count) throws IOException {
+        SpillFile spillFile = new SpillFile(tempDir);
+        for (int i = 0; i < count; i++) {
+            spillFile.append(
+                    new InputChannelInfo(0, i % 2),
+                    ByteBuffer.wrap(new byte[] {(byte) i, (byte) (i + 1)}));
+        }
+        return spillFile;
+    }
+
+    private static void assertSegmentsExist(List<SpillFile.SpillFileSegment> segs, boolean exists) {
+        for (SpillFile.SpillFileSegment seg : segs) {
+            assertThat(Files.exists(seg.path))
+                    .as("segment " + seg.path + " exists=" + exists)
+                    .isEqualTo(exists);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileSnapshotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileSnapshotTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link SpillFile#snapshot()}. */
+class SpillFileSnapshotTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testSnapshotIsImmutable() throws IOException {
+        try (SpillFile spillFile = new SpillFile(tempDir)) {
+            InputChannelInfo ch = new InputChannelInfo(0, 0);
+            spillFile.append(ch, ByteBuffer.wrap(bytes(1, 2, 3)));
+            spillFile.append(ch, ByteBuffer.wrap(bytes(4, 5)));
+
+            SpillFile.Snapshot snap = spillFile.snapshot();
+            List<SpillFile.Entry> entries = snap.getEntries();
+            List<SpillFile.SpillFileSegment> segments = snap.getSegments();
+
+            assertThatThrownBy(() -> entries.add(null))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> segments.add(null))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    void testAppendAfterSnapshotDoesNotAffectSnapshot() throws IOException {
+        try (SpillFile spillFile = new SpillFile(tempDir)) {
+            InputChannelInfo ch = new InputChannelInfo(0, 0);
+            spillFile.append(ch, ByteBuffer.wrap(bytes(1, 2, 3)));
+
+            SpillFile.Snapshot snap = spillFile.snapshot();
+            int entryCountBefore = snap.getEntries().size();
+            int segmentCountBefore = snap.getSegments().size();
+
+            // Append more data after snapshot — must not appear in the previous snapshot.
+            spillFile.append(ch, ByteBuffer.wrap(bytes(4, 5)));
+            spillFile.append(ch, ByteBuffer.wrap(bytes(6, 7, 8, 9)));
+
+            assertThat(snap.getEntries()).hasSize(entryCountBefore);
+            assertThat(snap.getSegments()).hasSize(segmentCountBefore);
+
+            // The live SpillFile reflects the new appends.
+            assertThat(spillFile.entries()).hasSize(entryCountBefore + 2);
+        }
+    }
+
+    @Test
+    void testMultipleSnapshotsAreIndependent() throws IOException {
+        try (SpillFile spillFile = new SpillFile(tempDir)) {
+            InputChannelInfo ch = new InputChannelInfo(0, 0);
+            spillFile.append(ch, ByteBuffer.wrap(bytes(1)));
+
+            SpillFile.Snapshot s1 = spillFile.snapshot();
+
+            spillFile.append(ch, ByteBuffer.wrap(bytes(2, 3)));
+            SpillFile.Snapshot s2 = spillFile.snapshot();
+
+            spillFile.append(ch, ByteBuffer.wrap(bytes(4, 5, 6)));
+            SpillFile.Snapshot s3 = spillFile.snapshot();
+
+            // Each snapshot reflects the entries up to its own capture point.
+            assertThat(s1.getEntries()).hasSize(1);
+            assertThat(s2.getEntries()).hasSize(2);
+            assertThat(s3.getEntries()).hasSize(3);
+
+            // The earlier snapshots are not affected by later snapshots' captures.
+            assertThat(s1.getEntries().get(0).length).isEqualTo(1);
+            assertThat(s2.getEntries().get(1).length).isEqualTo(2);
+            assertThat(s3.getEntries().get(2).length).isEqualTo(3);
+        }
+    }
+
+    private static byte[] bytes(int... values) {
+        byte[] out = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            out[i] = (byte) values[i];
+        }
+        return out;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link SpillFile}. */
+class SpillFileTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testAppendRoundtrip() throws IOException {
+        try (SpillFile spillFile = new SpillFile(tempDir)) {
+            InputChannelInfo channelInfo = new InputChannelInfo(0, 1);
+            byte[] payload = bytes(0xAB, 0xCD, 0xEF, 0x12, 0x34);
+            spillFile.append(channelInfo, ByteBuffer.wrap(payload));
+
+            List<SpillFile.Entry> entries = spillFile.entries();
+            assertThat(entries).hasSize(1);
+            SpillFile.Entry entry = entries.get(0);
+            assertThat(entry.channelInfo).isEqualTo(channelInfo);
+            assertThat(entry.segmentIndex).isEqualTo(0);
+            assertThat(entry.offset).isEqualTo(0L);
+            assertThat(entry.length).isEqualTo(payload.length);
+
+            byte[] readBack = spillFile.readBytes(entry.segmentIndex, entry.offset, entry.length);
+            assertThat(readBack).isEqualTo(payload);
+        }
+    }
+
+    @Test
+    void testSegmentRotationAcrossDefaultSegmentSize() throws IOException {
+        // Use a tiny custom segment size to exercise rotation deterministically. Tests do not
+        // depend on the 64 MiB default for this property — only on the constant-vs-magic-number
+        // discipline, which the constant DEFAULT_SEGMENT_SIZE_BYTES enforces in production.
+        long segmentSize = 16L;
+        try (SpillFile spillFile = new SpillFile(tempDir, segmentSize)) {
+            InputChannelInfo channelInfo = new InputChannelInfo(0, 0);
+            byte[] payloadA = bytes(1, 2, 3, 4, 5, 6, 7, 8, 9, 10); // 10 bytes
+            byte[] payloadB = bytes(11, 12, 13, 14, 15, 16, 17, 18); // 8 bytes — would overflow
+            byte[] payloadC = bytes(19, 20, 21, 22, 23); // 5 bytes — fits in segment 1
+
+            spillFile.append(channelInfo, ByteBuffer.wrap(payloadA));
+            spillFile.append(channelInfo, ByteBuffer.wrap(payloadB));
+            spillFile.append(channelInfo, ByteBuffer.wrap(payloadC));
+
+            List<SpillFile.Entry> entries = spillFile.entries();
+            assertThat(entries).hasSize(3);
+            assertThat(entries.get(0).segmentIndex).isEqualTo(0);
+            assertThat(entries.get(0).offset).isEqualTo(0L);
+            assertThat(entries.get(1).segmentIndex)
+                    .as("payload B should rotate to segment 1 since 10+8 > segmentSize")
+                    .isEqualTo(1);
+            assertThat(entries.get(1).offset).isEqualTo(0L);
+            assertThat(entries.get(2).segmentIndex)
+                    .as("payload C fits in segment 1 after payload B")
+                    .isEqualTo(1);
+            assertThat(entries.get(2).offset).isEqualTo((long) payloadB.length);
+
+            assertThat(spillFile.segments()).hasSize(2);
+
+            byte[] readA = spillFile.readBytes(0, 0L, payloadA.length);
+            byte[] readB = spillFile.readBytes(1, 0L, payloadB.length);
+            byte[] readC = spillFile.readBytes(1, payloadB.length, payloadC.length);
+            assertThat(readA).isEqualTo(payloadA);
+            assertThat(readB).isEqualTo(payloadB);
+            assertThat(readC).isEqualTo(payloadC);
+        }
+    }
+
+    @Test
+    void testAppendAfterCloseThrows() throws IOException {
+        SpillFile spillFile = new SpillFile(tempDir);
+        spillFile.close();
+        assertThatThrownBy(
+                        () ->
+                                spillFile.append(
+                                        new InputChannelInfo(0, 0),
+                                        ByteBuffer.wrap(bytes(1, 2, 3))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("closed");
+    }
+
+    @Test
+    void testEntriesMatchDiskLayout() throws IOException {
+        // Two channels interleaved within one segment. Verify that each entry's (offset, length)
+        // matches both the cumulative bytes written and the actual bytes recoverable from disk.
+        long segmentSize = 256L;
+        try (SpillFile spillFile = new SpillFile(tempDir, segmentSize)) {
+            InputChannelInfo c0 = new InputChannelInfo(0, 0);
+            InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+            byte[] p0 = bytes(0xA, 0xB);
+            byte[] p1 = bytes(0xC, 0xD, 0xE);
+            byte[] p2 = bytes(0xF);
+            byte[] p3 = bytes(0x1, 0x2, 0x3, 0x4);
+
+            spillFile.append(c0, ByteBuffer.wrap(p0));
+            spillFile.append(c1, ByteBuffer.wrap(p1));
+            spillFile.append(c0, ByteBuffer.wrap(p2));
+            spillFile.append(c1, ByteBuffer.wrap(p3));
+
+            List<SpillFile.Entry> entries = spillFile.entries();
+            assertThat(entries).hasSize(4);
+
+            long cumulative = 0;
+            byte[][] payloads = {p0, p1, p2, p3};
+            InputChannelInfo[] channels = {c0, c1, c0, c1};
+            for (int i = 0; i < entries.size(); i++) {
+                SpillFile.Entry e = entries.get(i);
+                assertThat(e.segmentIndex).isEqualTo(0);
+                assertThat(e.offset).isEqualTo(cumulative);
+                assertThat(e.length).isEqualTo(payloads[i].length);
+                assertThat(e.channelInfo).isEqualTo(channels[i]);
+                byte[] readBack = spillFile.readBytes(0, e.offset, e.length);
+                assertThat(readBack).isEqualTo(payloads[i]);
+                cumulative += payloads[i].length;
+            }
+        }
+    }
+
+    @Test
+    void testCloseIsIdempotent() throws IOException {
+        SpillFile spillFile = new SpillFile(tempDir);
+        spillFile.append(new InputChannelInfo(0, 0), ByteBuffer.wrap(bytes(1, 2, 3)));
+        spillFile.close();
+        assertThat(spillFile.isClosed()).isTrue();
+        // Second close must not throw.
+        spillFile.close();
+        assertThat(spillFile.isClosed()).isTrue();
+    }
+
+    private static byte[] bytes(int... values) {
+        byte[] out = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            out[i] = (byte) values[i];
+        }
+        return out;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SpillFileWriterTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.memory.MemoryManager;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link SpillFileWriter}. */
+class SpillFileWriterTest {
+
+    @TempDir Path tempDir;
+
+    private static final int BUF_SIZE = MemoryManager.DEFAULT_PAGE_SIZE;
+
+    @Test
+    void testWriteDelegates() throws Exception {
+        SpillFile spillFile = new SpillFile(tempDir);
+        FilteredBufferWriter accumulator = newAccumulator(spillFile);
+        try (SpillFileWriter writer = new SpillFileWriter(spillFile, accumulator)) {
+            InputChannelInfo c0 = new InputChannelInfo(0, 0);
+            writer.write(c0, payloadBuffer(8, (byte) 0x11));
+            writer.write(c0, payloadBuffer(13, (byte) 0x22));
+        }
+        // After close, all bytes (8 + 13 = 21) end up as a single entry — the writer accumulated
+        // them in one post-filter buffer and the close-time flush stamped a single record.
+        assertThat(spillFile.entries()).hasSize(1);
+        assertThat(spillFile.entries().get(0).length).isEqualTo(8 + 13);
+        assertThat(spillFile.entries().get(0).channelInfo).isEqualTo(new InputChannelInfo(0, 0));
+    }
+
+    @Test
+    void testCloseOrdering() throws Exception {
+        // close() must call FilteredBufferWriter.close() BEFORE SpillFile.close(): the
+        // accumulator flushes residual bytes, which requires the spill file's FileChannels to
+        // still be open. The SpillFile close inside the facade after the accumulator returns is
+        // an idempotent no-op, but its position is load-bearing for the invariant.
+        //
+        // Verification strategy: drive a write so that there is a non-zero residual, then close.
+        // If the order were swapped (SpillFile.close before accumulator.close), the accumulator
+        // would attempt to write to a closed FileChannel and throw — which is exactly the
+        // failure mode this test exists to prevent.
+        SpillFile spillFile = new SpillFile(tempDir);
+        FilteredBufferWriter accumulator = newAccumulator(spillFile);
+        SpillFileWriter writer = new SpillFileWriter(spillFile, accumulator);
+
+        writer.write(new InputChannelInfo(0, 0), payloadBuffer(7, (byte) 0x33));
+        assertThat(spillFile.entries()).isEmpty();
+
+        writer.close();
+
+        assertThat(spillFile.entries()).hasSize(1);
+        assertThat(spillFile.entries().get(0).length).isEqualTo(7);
+        assertThat(spillFile.isClosed()).isTrue();
+    }
+
+    @Test
+    void testCloseIsIdempotent() throws Exception {
+        SpillFile spillFile = new SpillFile(tempDir);
+        FilteredBufferWriter accumulator = newAccumulator(spillFile);
+        SpillFileWriter writer = new SpillFileWriter(spillFile, accumulator);
+
+        writer.close();
+        // Second close must not throw and must not produce extra entries.
+        writer.close();
+        writer.close();
+        assertThat(spillFile.isClosed()).isTrue();
+    }
+
+    @Test
+    void testGetSpillFileReturnsConstructorArg() {
+        SpillFile spillFile = new SpillFile(tempDir);
+        FilteredBufferWriter accumulator = newAccumulator(spillFile);
+        SpillFileWriter writer = new SpillFileWriter(spillFile, accumulator);
+        assertThat(writer.getSpillFile()).isSameAs(spillFile);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------------------------
+
+    private static FilteredBufferWriter newAccumulator(SpillFile spillFile) {
+        return new FilteredBufferWriter(
+                spillFile,
+                newHeapBuffer(BUF_SIZE),
+                newHeapBuffer(BUF_SIZE),
+                () -> newHeapBuffer(BUF_SIZE));
+    }
+
+    private static Buffer newHeapBuffer(int size) {
+        MemorySegment seg = MemorySegmentFactory.allocateUnpooledSegment(size);
+        return new NetworkBuffer(seg, MemorySegment::free);
+    }
+
+    private static Buffer payloadBuffer(int length, byte fill) {
+        MemorySegment seg = MemorySegmentFactory.allocateUnpooledSegment(length);
+        byte[] data = new byte[length];
+        java.util.Arrays.fill(data, fill);
+        seg.put(0, data);
+        NetworkBuffer buf = new NetworkBuffer(seg, MemorySegment::free);
+        buf.setSize(length);
+        return buf;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/UnalignedCheckpointDuringRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/UnalignedCheckpointDuringRecoveryITCase.java
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-package org.apache.flink.test.checkpointing;
+package org.apache.flink.runtime.checkpoint.channel;
 
-import org.apache.flink.runtime.checkpoint.channel.DiskSnapshot;
-import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.util.CloseableIterator;
 
 import org.junit.jupiter.api.Test;
@@ -95,7 +93,7 @@ class UnalignedCheckpointDuringRecoveryITCase {
     }
 
     @Test
-    void testEmptyDiskSnapshotIsConsumedOnceByStep3() {
+    void testEmptyDiskSnapshotIsConsumedOnceByStep3() throws Exception {
         AtomicBoolean closed = new AtomicBoolean(false);
         CloseableIterator<DiskSnapshot.Chunk> empty =
                 new CloseableIterator<DiskSnapshot.Chunk>() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -68,7 +68,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayDeque;
 import java.util.stream.Stream;
 
 import static org.apache.flink.runtime.io.network.netty.PartitionRequestQueueTest.blockChannel;
@@ -952,8 +951,7 @@ class CreditBasedPartitionRequestClientHandlerTest {
                     2,
                     new SimpleCounter(),
                     new SimpleCounter(),
-                    ChannelStateWriter.NO_OP,
-                    new ArrayDeque<>());
+                    ChannelStateWriter.NO_OP);
             this.expectedMessage = expectedMessage;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestRegistrationTest.java
@@ -44,7 +44,6 @@ import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayDeque;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -249,8 +248,7 @@ class PartitionRequestRegistrationTest {
                     2,
                     new SimpleCounter(),
                     new SimpleCounter(),
-                    ChannelStateWriter.NO_OP,
-                    new ArrayDeque<>());
+                    ChannelStateWriter.NO_OP);
             this.latch = latch;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
 
 import java.net.InetSocketAddress;
-import java.util.ArrayDeque;
 
 import static org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateTest.TestingResultPartitionManager;
 
@@ -154,6 +153,48 @@ public class InputChannelBuilder {
     }
 
     public LocalInputChannel buildLocalChannel(SingleInputGate inputGate) {
+        LocalInputChannel channel =
+                new LocalInputChannel(
+                        inputGate,
+                        channelIndex,
+                        partitionId,
+                        subpartitionIndexSet,
+                        partitionManager,
+                        taskEventPublisher,
+                        initialBackoff,
+                        maxBackoff,
+                        metrics.getNumBytesInLocalCounter(),
+                        metrics.getNumBuffersInLocalCounter(),
+                        stateWriter);
+        markNoRecovery(channel);
+        return channel;
+    }
+
+    public RemoteInputChannel buildRemoteChannel(SingleInputGate inputGate) {
+        RemoteInputChannel channel =
+                new RemoteInputChannel(
+                        inputGate,
+                        channelIndex,
+                        partitionId,
+                        subpartitionIndexSet,
+                        connectionID,
+                        connectionManager,
+                        initialBackoff,
+                        maxBackoff,
+                        partitionRequestListenerTimeout,
+                        networkBuffersPerChannel,
+                        metrics.getNumBytesInRemoteCounter(),
+                        metrics.getNumBuffersInRemoteCounter(),
+                        stateWriter);
+        markNoRecovery(channel);
+        return channel;
+    }
+
+    /**
+     * Same as {@link #buildLocalChannel(SingleInputGate)} but does NOT auto-mark the recovery phase
+     * complete. Used by tests that want to explicitly drive the recovery push interface.
+     */
+    public LocalInputChannel buildLocalChannelForRecoveryTest(SingleInputGate inputGate) {
         return new LocalInputChannel(
                 inputGate,
                 channelIndex,
@@ -165,11 +206,14 @@ public class InputChannelBuilder {
                 maxBackoff,
                 metrics.getNumBytesInLocalCounter(),
                 metrics.getNumBuffersInLocalCounter(),
-                stateWriter,
-                new ArrayDeque<>());
+                stateWriter);
     }
 
-    public RemoteInputChannel buildRemoteChannel(SingleInputGate inputGate) {
+    /**
+     * Same as {@link #buildRemoteChannel(SingleInputGate)} but does NOT auto-mark the recovery
+     * phase complete. Used by tests that want to explicitly drive the recovery push interface.
+     */
+    public RemoteInputChannel buildRemoteChannelForRecoveryTest(SingleInputGate inputGate) {
         return new RemoteInputChannel(
                 inputGate,
                 channelIndex,
@@ -183,8 +227,21 @@ public class InputChannelBuilder {
                 networkBuffersPerChannel,
                 metrics.getNumBytesInRemoteCounter(),
                 metrics.getNumBuffersInRemoteCounter(),
-                stateWriter,
-                new ArrayDeque<>());
+                stateWriter);
+    }
+
+    /**
+     * Test channels built via this builder do not undergo recovery by default; mark the recovery
+     * phase complete so {@code getNextBuffer()} falls through to the live path immediately,
+     * mirroring what {@code UnknownInputChannel.toLocalInputChannel/toRemoteInputChannel} does in
+     * production.
+     */
+    private static void markNoRecovery(RecoverableInputChannel channel) {
+        try {
+            channel.finishReadRecoveredState();
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     public LocalRecoveredInputChannel buildLocalRecoveredChannel(SingleInputGate inputGate) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -61,7 +61,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -669,7 +668,7 @@ class LocalInputChannelTest {
 
     @Test
     void testGetBuffersInUseCountIncludesToBeConsumedBuffers() throws Exception {
-        // given: Local input channel with recovered buffers in toBeConsumedBuffers
+        // given: Local input channel with recovered buffers pushed via the recovery interface
         ResultSubpartitionView subpartitionView =
                 InputChannelTestUtils.createResultSubpartitionView(
                         createFilledFinishedBufferConsumer(4096),
@@ -677,12 +676,6 @@ class LocalInputChannelTest {
         TestingResultPartitionManager partitionManager =
                 new TestingResultPartitionManager(subpartitionView);
         final SingleInputGate inputGate = createSingleInputGate(1);
-
-        // Create 3 recovered buffers
-        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
-        recoveredBuffers.add(TestBufferFactory.createBuffer(32));
-        recoveredBuffers.add(TestBufferFactory.createBuffer(32));
-        recoveredBuffers.add(TestBufferFactory.createBuffer(32));
 
         final LocalInputChannel localChannel =
                 new LocalInputChannel(
@@ -696,10 +689,14 @@ class LocalInputChannelTest {
                         0,
                         new SimpleCounter(),
                         new SimpleCounter(),
-                        ChannelStateWriter.NO_OP,
-                        recoveredBuffers);
+                        ChannelStateWriter.NO_OP);
 
         inputGate.setInputChannels(localChannel);
+
+        // Push 3 recovered buffers via the new RecoverableInputChannel interface.
+        localChannel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(32));
+        localChannel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(32));
+        localChannel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(32));
 
         // then: Before requesting subpartitions, buffers in use should include recovered buffers
         assertThat(localChannel.getBuffersInUseCount()).isEqualTo(3);
@@ -715,12 +712,8 @@ class LocalInputChannelTest {
 
     @Test
     void testGetNextBufferWithMigratedRecoveredBuffers() throws Exception {
-        // given: LocalInputChannel with recovered buffers migrated from RecoveredInputChannel
+        // given: LocalInputChannel with recovered buffers delivered via push interface
         SingleInputGate inputGate = createSingleInputGate(1);
-
-        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
-        recoveredBuffers.add(TestBufferFactory.createBuffer(10));
-        recoveredBuffers.add(TestBufferFactory.createBuffer(20));
 
         LocalInputChannel channel =
                 new LocalInputChannel(
@@ -734,10 +727,13 @@ class LocalInputChannelTest {
                         0,
                         new SimpleCounter(),
                         new SimpleCounter(),
-                        ChannelStateWriter.NO_OP,
-                        recoveredBuffers);
+                        ChannelStateWriter.NO_OP);
 
         inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(10));
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(20));
+        channel.finishReadRecoveredState();
 
         // then: Can read recovered buffers even before requestSubpartitions()
         Optional<InputChannel.BufferAndAvailability> first = channel.getNextBuffer();
@@ -752,13 +748,8 @@ class LocalInputChannelTest {
 
     @Test
     void testCheckpointStartedPersistsRecoveredBuffers() throws Exception {
-        // given: Local input channel with recovered buffers
+        // given: Local input channel with recovered buffers pushed via the recovery interface
         SingleInputGate inputGate = new SingleInputGateBuilder().build();
-
-        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
-        recoveredBuffers.add(TestBufferFactory.createBuffer(10));
-        recoveredBuffers.add(TestBufferFactory.createBuffer(20));
-        recoveredBuffers.add(TestBufferFactory.createBuffer(30));
 
         RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
 
@@ -774,19 +765,22 @@ class LocalInputChannelTest {
                         0,
                         new SimpleCounter(),
                         new SimpleCounter(),
-                        stateWriter,
-                        recoveredBuffers);
+                        stateWriter);
 
         inputGate.setInputChannels(channel);
 
-        // when: Checkpoint is started
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(10));
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(20));
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(30));
+
+        // when: Checkpoint is started while in recovery (recoveredBuffers non-empty, flag false)
         CheckpointOptions options =
                 CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
         stateWriter.start(1L, options);
         CheckpointBarrier barrier = new CheckpointBarrier(1L, 0L, options);
         channel.checkpointStarted(barrier);
 
-        // then: All 3 recovered buffers should be persisted as inflight data
+        // then: All 3 recovered buffers should be persisted as inflight data via addInputData
         List<Buffer> persistedBuffers = stateWriter.getAddedInput().get(channel.getChannelInfo());
         assertThat(persistedBuffers).isNotNull().hasSize(3);
         assertThat(persistedBuffers.stream().mapToInt(Buffer::getSize).toArray())
@@ -824,9 +818,6 @@ class LocalInputChannelTest {
         // given: Local input channel with recovered buffers but NO subpartition view initialized
         SingleInputGate inputGate = new SingleInputGateBuilder().build();
 
-        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
-        recoveredBuffers.add(TestBufferFactory.createBuffer(10));
-
         LocalInputChannel channel =
                 new LocalInputChannel(
                         inputGate,
@@ -839,10 +830,10 @@ class LocalInputChannelTest {
                         0,
                         new SimpleCounter(),
                         new SimpleCounter(),
-                        ChannelStateWriter.NO_OP,
-                        recoveredBuffers);
+                        ChannelStateWriter.NO_OP);
 
         inputGate.setInputChannels(channel);
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(10));
         // Do NOT call channel.requestSubpartitions() — subpartitionView stays null
 
         channel.notifyPriorityEvent(0);
@@ -962,11 +953,6 @@ class LocalInputChannelTest {
         TestingResultPartitionManager partitionManager =
                 new TestingResultPartitionManager(subpartitionView);
 
-        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
-        for (int size : recoveredBufferSizes) {
-            recoveredBuffers.add(TestBufferFactory.createBuffer(size));
-        }
-
         LocalInputChannel channel =
                 new LocalInputChannel(
                         inputGate,
@@ -979,10 +965,14 @@ class LocalInputChannelTest {
                         0,
                         new SimpleCounter(),
                         new SimpleCounter(),
-                        stateWriter,
-                        recoveredBuffers);
+                        stateWriter);
 
         inputGate.setInputChannels(channel);
+
+        for (int size : recoveredBufferSizes) {
+            channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(size));
+        }
+
         channel.requestSubpartitions();
 
         return new ChannelAndSubpartition(channel, subpartition);
@@ -996,6 +986,350 @@ class LocalInputChannelTest {
             this.channel = channel;
             this.subpartition = subpartition;
         }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // RecoverableInputChannel push-based recovery tests
+    // ---------------------------------------------------------------------------------------------
+
+    private static LocalInputChannel newPushOnlyLocalChannel(
+            SingleInputGate inputGate, ChannelStateWriter stateWriter) {
+        return new LocalInputChannel(
+                inputGate,
+                0,
+                new ResultPartitionID(),
+                new ResultSubpartitionIndexSet(0),
+                new ResultPartitionManager(),
+                new TaskEventDispatcher(),
+                0,
+                0,
+                new SimpleCounter(),
+                new SimpleCounter(),
+                stateWriter);
+    }
+
+    @Test
+    void testOnRecoveredStateBufferEnqueues() throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, ChannelStateWriter.NO_OP);
+        inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(11));
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(22));
+
+        Optional<InputChannel.BufferAndAvailability> first = channel.getNextBuffer();
+        assertThat(first).isPresent();
+        assertThat(first.get().buffer().getSize()).isEqualTo(11);
+        Optional<InputChannel.BufferAndAvailability> second = channel.getNextBuffer();
+        assertThat(second).isPresent();
+        assertThat(second.get().buffer().getSize()).isEqualTo(22);
+    }
+
+    @Test
+    void testOnRecoveredStateBufferOnReleasedChannelIsSilentlyRecycled() throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, ChannelStateWriter.NO_OP);
+        inputGate.setInputChannels(channel);
+        channel.releaseAllResources();
+
+        Buffer b = TestBufferFactory.createBuffer(33);
+        channel.onRecoveredStateBuffer(b);
+        assertThat(b.isRecycled()).isTrue();
+    }
+
+    @Test
+    void testFinishReadRecoveredStateFlipsFlagOnce() throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, ChannelStateWriter.NO_OP);
+        inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        channel.finishReadRecoveredState();
+        assertThat(channel.getStateConsumedFuture()).isNotDone();
+        channel.finishReadRecoveredState();
+        assertThat(channel.getStateConsumedFuture()).isNotDone();
+        channel.getNextBuffer();
+        assertThat(channel.getStateConsumedFuture()).isDone();
+    }
+
+    @Test
+    void testOnRecoveredStateBufferNotifiesChannelNonEmptyOnEmptyToNonEmptyTransition()
+            throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, ChannelStateWriter.NO_OP);
+        inputGate.setInputChannels(channel);
+
+        CompletableFuture<?> availability = inputGate.getAvailableFuture();
+        assertThat(availability).isNotDone();
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        assertThat(availability).isDone();
+    }
+
+    @Test
+    void testInRecoveryBoundaryFlagFalseQueueEmptyReturnsEmpty() throws Exception {
+        // Drive into the (flag=false, queue=empty) boundary by pushing one buffer, polling it,
+        // and verifying the channel does not yet expose a master-path result.
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, ChannelStateWriter.NO_OP);
+        inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        channel.getNextBuffer();
+        // Queue is empty; no finishReadRecoveredState was called. Without the subpartitionView
+        // active, the channel returns empty.
+        Optional<InputChannel.BufferAndAvailability> result = channel.getNextBuffer();
+        assertThat(result).isNotPresent();
+    }
+
+    @Test
+    void testInRecoveryBoundaryFlagFalseQueueNonEmptyPolls() throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, ChannelStateWriter.NO_OP);
+        inputGate.setInputChannels(channel);
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(7));
+        Optional<InputChannel.BufferAndAvailability> r = channel.getNextBuffer();
+        assertThat(r).isPresent();
+        assertThat(r.get().buffer().getSize()).isEqualTo(7);
+    }
+
+    @Test
+    void testInRecoveryBoundaryFlagTrueQueueNonEmptyPolls() throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, ChannelStateWriter.NO_OP);
+        inputGate.setInputChannels(channel);
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(8));
+        channel.finishReadRecoveredState();
+        assertThat(channel.getStateConsumedFuture()).isNotDone();
+        Optional<InputChannel.BufferAndAvailability> r = channel.getNextBuffer();
+        assertThat(r).isPresent();
+        assertThat(r.get().buffer().getSize()).isEqualTo(8);
+        assertThat(channel.getStateConsumedFuture()).isDone();
+    }
+
+    @Test
+    void testInRecoveryBoundaryFlagTrueQueueEmptyFallsToMasterPath() throws Exception {
+        // flag=true, queue=empty → channel is NOT in recovery → master path takes over. Without a
+        // subpartition view, the master path raises IllegalStateException via
+        // checkAndWaitForSubpartitionView, which is the exact pre-Phase-2 behaviour and proves the
+        // recovery branch is not swallowing the call.
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, ChannelStateWriter.NO_OP);
+        inputGate.setInputChannels(channel);
+        channel.finishReadRecoveredState();
+        assertThatThrownBy(channel::getNextBuffer)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Queried for a buffer before requesting the subpartition");
+    }
+
+    @Test
+    void testPriorityEventDuringRecoveryFetchedFromSubpartitionView() throws Exception {
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        ChannelAndSubpartition ctx = createChannelWithRecoveredBuffers(stateWriter, 10, 20);
+
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
+        ctx.subpartition.add(
+                EventSerializer.toBufferConsumer(new CheckpointBarrier(1L, 0L, options), true));
+        ctx.channel.notifyPriorityEvent(0);
+
+        Optional<InputChannel.BufferAndAvailability> first = ctx.channel.getNextBuffer();
+        assertThat(first).isPresent();
+        assertThat(first.get().buffer().getDataType().hasPriority()).isTrue();
+    }
+
+    @Test
+    void testPriorityEventDuringRecoveryResetAfterNonPriority() throws Exception {
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        ChannelAndSubpartition ctx = createChannelWithRecoveredBuffers(stateWriter, 10);
+
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
+        ctx.subpartition.add(
+                EventSerializer.toBufferConsumer(new CheckpointBarrier(1L, 0L, options), true));
+        ctx.subpartition.add(createFilledFinishedBufferConsumer(32));
+        ctx.channel.notifyPriorityEvent(0);
+
+        // Pull the priority barrier — afterwards hasPendingPriorityEvent is reset.
+        Optional<InputChannel.BufferAndAvailability> priority = ctx.channel.getNextBuffer();
+        assertThat(priority).isPresent();
+        // Next pull returns the recovered buffer (queue is preferred over subpartitionView).
+        Optional<InputChannel.BufferAndAvailability> recovered = ctx.channel.getNextBuffer();
+        assertThat(recovered).isPresent();
+        assertThat(recovered.get().buffer().isBuffer()).isTrue();
+        assertThat(recovered.get().buffer().getSize()).isEqualTo(10);
+    }
+
+    @Test
+    void testCheckpointStartedScansRecoveredBuffersUpToBarrier() throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, stateWriter);
+        inputGate.setInputChannels(channel);
+
+        Buffer b1 = TestBufferFactory.createBuffer(1);
+        Buffer b2 = TestBufferFactory.createBuffer(2);
+        Buffer b3 = TestBufferFactory.createBuffer(3);
+        channel.onRecoveredStateBuffer(b1);
+        channel.onRecoveredStateBuffer(b2);
+        channel.onRecoveredStateBuffer(
+                new org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier(1L));
+        channel.onRecoveredStateBuffer(b3);
+
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
+        stateWriter.start(1L, options);
+        channel.checkpointStarted(new CheckpointBarrier(1L, 0L, options));
+
+        List<Buffer> persisted = stateWriter.getAddedInput().get(channel.getChannelInfo());
+        assertThat(persisted).hasSize(2);
+        assertThat(persisted.stream().mapToInt(Buffer::getSize).toArray()).containsExactly(1, 2);
+    }
+
+    @Test
+    void testCheckpointStartedRetainsPreBarrierBuffers() throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, stateWriter);
+        inputGate.setInputChannels(channel);
+
+        Buffer b1 = TestBufferFactory.createBuffer(1);
+        channel.onRecoveredStateBuffer(b1);
+        channel.onRecoveredStateBuffer(
+                new org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier(1L));
+
+        int before = b1.refCnt();
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
+        stateWriter.start(1L, options);
+        channel.checkpointStarted(new CheckpointBarrier(1L, 0L, options));
+        // Pre-barrier buffers are retained for the writer; their ref-count stays at or above the
+        // pre-checkpoint value.
+        assertThat(b1.refCnt()).isGreaterThanOrEqualTo(before);
+    }
+
+    @Test
+    void testCheckpointStartedRemovesSentinel() throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, stateWriter);
+        inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        channel.onRecoveredStateBuffer(
+                new org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier(1L));
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(2));
+
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
+        stateWriter.start(1L, options);
+        channel.checkpointStarted(new CheckpointBarrier(1L, 0L, options));
+
+        // After checkpointStarted, the next two polls should drain (1) and then (2), with the
+        // sentinel having been removed by the scan.
+        Optional<InputChannel.BufferAndAvailability> h1 = channel.getNextBuffer();
+        assertThat(h1).isPresent();
+        Optional<InputChannel.BufferAndAvailability> h2 = channel.getNextBuffer();
+        assertThat(h2).isPresent();
+        assertThat(h2.get().buffer().getSize()).isEqualTo(2);
+    }
+
+    @Test
+    void testCheckpointStartedNestedCpIds() throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, stateWriter);
+        inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        channel.onRecoveredStateBuffer(
+                new org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier(1L));
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(2));
+        channel.onRecoveredStateBuffer(
+                new org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier(2L));
+
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
+        stateWriter.start(1L, options);
+        channel.checkpointStarted(new CheckpointBarrier(1L, 0L, options));
+
+        List<Buffer> persisted = stateWriter.getAddedInput().get(channel.getChannelInfo());
+        assertThat(persisted).hasSize(1);
+        assertThat(persisted.get(0).getSize()).isEqualTo(1);
+    }
+
+    @Test
+    void testCheckpointStartedNotInRecoveryUsesMasterPath() throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, stateWriter);
+        inputGate.setInputChannels(channel);
+
+        // No recovery — checkpointStarted goes through the master path, which calls
+        // startPersisting(barrier.getId(), Collections.emptyList()).
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
+        stateWriter.start(1L, options);
+        channel.checkpointStarted(new CheckpointBarrier(1L, 0L, options));
+
+        assertThat(stateWriter.getAddedInput().get(channel.getChannelInfo())).isNullOrEmpty();
+    }
+
+    @Test
+    void testReceivedBuffersHasNoLiveDataBufferIsTrueOnLocal() throws Exception {
+        // Local has no receivedBuffers; the helper is trivially true. We exercise the
+        // in-recovery checkpointStarted branch without any "live data" infrastructure to confirm
+        // the channel does not crash.
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, stateWriter);
+        inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        channel.onRecoveredStateBuffer(
+                new org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier(1L));
+
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
+        stateWriter.start(1L, options);
+        // Should not throw — the Local-side helper is trivially true.
+        channel.checkpointStarted(new CheckpointBarrier(1L, 0L, options));
+    }
+
+    @Test
+    void testStateConsumedFutureCompletesOnFinishReadRecoveredStateWhenQueueEmpty()
+            throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, ChannelStateWriter.NO_OP);
+        inputGate.setInputChannels(channel);
+        assertThat(channel.getStateConsumedFuture()).isNotDone();
+        channel.finishReadRecoveredState();
+        assertThat(channel.getStateConsumedFuture()).isDone();
+    }
+
+    @Test
+    void testStateConsumedFutureCompletesOnLastConsumeWhenFlagTrue() throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, ChannelStateWriter.NO_OP);
+        inputGate.setInputChannels(channel);
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        channel.finishReadRecoveredState();
+        assertThat(channel.getStateConsumedFuture()).isNotDone();
+        channel.getNextBuffer();
+        assertThat(channel.getStateConsumedFuture()).isDone();
+    }
+
+    @Test
+    void testStateConsumedFutureCompletesOnce() throws Exception {
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        LocalInputChannel channel = newPushOnlyLocalChannel(inputGate, ChannelStateWriter.NO_OP);
+        inputGate.setInputChannels(channel);
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        channel.finishReadRecoveredState();
+        channel.getNextBuffer();
+        assertThat(channel.getStateConsumedFuture()).isDone();
+        channel.finishReadRecoveredState();
+        channel.finishReadRecoveredState();
+        assertThat(channel.getStateConsumedFuture()).isDone();
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalRecoveredInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalRecoveredInputChannelTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.util.TestBufferFactory;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link LocalRecoveredInputChannel}. */
+class LocalRecoveredInputChannelTest {
+
+    /**
+     * Verifies that the migration path inside {@code RecoveredInputChannel.toInputChannel()} now
+     * uses {@link RecoverableInputChannel#onRecoveredStateBuffer} followed by {@link
+     * RecoverableInputChannel#finishReadRecoveredState()}: every remaining buffer is delivered in
+     * order to the physical {@link LocalInputChannel}, and the resulting channel can be consumed
+     * via {@code getNextBuffer()}.
+     */
+    @Test
+    void testToInputChannelUsesOnRecoveredStateBufferAndFinishReadRecoveredState()
+            throws Exception {
+        SingleInputGate inputGate =
+                new SingleInputGateBuilder().setCheckpointingDuringRecoveryEnabled(true).build();
+        LocalRecoveredInputChannel recoveredChannel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(ChannelStateWriter.NO_OP)
+                        .buildLocalRecoveredChannel(inputGate);
+
+        Buffer b1 = TestBufferFactory.createBuffer(11);
+        Buffer b2 = TestBufferFactory.createBuffer(22);
+        recoveredChannel.onRecoveredStateBuffer(b1);
+        recoveredChannel.onRecoveredStateBuffer(b2);
+        recoveredChannel.finishReadRecoveredState();
+
+        InputChannel converted = recoveredChannel.toInputChannel();
+        assertThat(converted).isInstanceOf(LocalInputChannel.class);
+        LocalInputChannel localChannel = (LocalInputChannel) converted;
+        inputGate.setInputChannels(localChannel);
+
+        // Both buffers were migrated through the push interface and remain consumable in order.
+        Optional<InputChannel.BufferAndAvailability> first = localChannel.getNextBuffer();
+        assertThat(first).isPresent();
+        assertThat(first.get().buffer().getSize()).isEqualTo(11);
+
+        Optional<InputChannel.BufferAndAvailability> second = localChannel.getNextBuffer();
+        assertThat(second).isPresent();
+        assertThat(second.get().buffer().getSize()).isEqualTo(22);
+
+        // RecoveredInputChannel.finishReadRecoveredState appends an EndOfInputChannelStateEvent
+        // sentinel into receivedBuffers, which is also migrated into the new channel's
+        // recoveredBuffers queue. Drain it to fully complete the recovery phase.
+        Optional<InputChannel.BufferAndAvailability> tail = localChannel.getNextBuffer();
+        assertThat(tail).isPresent();
+
+        // After draining everything migrated, stateConsumedFuture is complete.
+        assertThat(localChannel.getStateConsumedFuture()).isDone();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelRequestBufferBlockingHeapFallbackRemovedTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelRequestBufferBlockingHeapFallbackRemovedTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
+import org.apache.flink.runtime.memory.MemoryManager;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link RecoveredInputChannel#requestBufferBlocking} no longer falls back to
+ * unpooled heap-segment allocation once the source channel's exclusive buffer pool is exhausted.
+ * Replaces the pre-Phase-4 heap path that fixed OOM by spilling instead.
+ */
+class RecoveredInputChannelRequestBufferBlockingHeapFallbackRemovedTest {
+
+    private NetworkBufferPool pool;
+
+    @AfterEach
+    void tearDown() {
+        if (pool != null) {
+            pool.destroy();
+            pool = null;
+        }
+    }
+
+    @Test
+    void testBufferPoolExhaustedBlocksRatherThanHeapAllocate() throws Exception {
+        // Tiny pool to force exhaustion quickly.
+        int totalSegments = 4;
+        pool = new NetworkBufferPool(totalSegments, MemoryManager.DEFAULT_PAGE_SIZE);
+        RecoveredInputChannel channel = buildChannel(pool, totalSegments);
+
+        // Drain the exclusive pool — request more buffers than the pool can offer.
+        for (int i = 0; i < totalSegments; i++) {
+            channel.requestBufferBlocking();
+        }
+
+        // The next request must block (no heap fallback path returns a non-pooled buffer).
+        CountDownLatch entered = new CountDownLatch(1);
+        AtomicReference<Buffer> result = new AtomicReference<>();
+        Thread blocker =
+                new Thread(
+                        () -> {
+                            try {
+                                entered.countDown();
+                                result.set(channel.requestBufferBlocking());
+                            } catch (Exception ignored) {
+                                // Thread will be interrupted at teardown.
+                            }
+                        },
+                        "blocking-requester");
+        blocker.start();
+
+        assertThat(entered.await(5, TimeUnit.SECONDS)).isTrue();
+        // Give the requester a chance to attempt allocation.
+        Thread.sleep(200);
+        assertThat(result.get()).as("buffer should not have been allocated").isNull();
+
+        // Interrupt the blocked thread to release the test.
+        blocker.interrupt();
+        blocker.join(5_000);
+    }
+
+    @Test
+    void testFilterOnPathTakesSameRouteAsFilterOff() throws Exception {
+        // Both filter-on and filter-off paths must allocate from the network pool — no behavior
+        // divergence based on isCheckpointingDuringRecoveryEnabled.
+        // Two channels each need an exclusive buffer; pool must hold both at once.
+        int exclusivePerChannel = 1;
+        int totalSegments = 4;
+        pool = new NetworkBufferPool(totalSegments, MemoryManager.DEFAULT_PAGE_SIZE);
+
+        Buffer filterOnBuf = buildChannel(pool, exclusivePerChannel, true).requestBufferBlocking();
+        Buffer filterOffBuf =
+                buildChannel(pool, exclusivePerChannel, false).requestBufferBlocking();
+
+        // Both must come from the pool — pre-Phase-4 the filter-on path would wrap the segment in
+        // FreeingBufferRecycler.INSTANCE for the heap-fallback case. Verify neither path takes
+        // that route (the recycler is the BufferManager's own implementation, not Freeing-).
+        assertThat(filterOnBuf.getMemorySegment()).isNotNull();
+        assertThat(filterOffBuf.getMemorySegment()).isNotNull();
+        assertThat(filterOnBuf.getRecycler().getClass().getName())
+                .doesNotContain("FreeingBufferRecycler");
+        assertThat(filterOffBuf.getRecycler().getClass().getName())
+                .doesNotContain("FreeingBufferRecycler");
+
+        filterOnBuf.recycleBuffer();
+        filterOffBuf.recycleBuffer();
+    }
+
+    private RecoveredInputChannel buildChannel(
+            NetworkBufferPool segmentProvider, int exclusivePerChannel) {
+        return buildChannel(segmentProvider, exclusivePerChannel, true);
+    }
+
+    private RecoveredInputChannel buildChannel(
+            NetworkBufferPool segmentProvider,
+            int exclusivePerChannel,
+            boolean checkpointingDuringRecoveryEnabled) {
+        try {
+            SingleInputGate inputGate =
+                    new SingleInputGateBuilder()
+                            .setSegmentProvider(segmentProvider)
+                            .setCheckpointingDuringRecoveryEnabled(
+                                    checkpointingDuringRecoveryEnabled)
+                            .build();
+            return new RecoveredInputChannel(
+                    inputGate,
+                    0,
+                    new ResultPartitionID(),
+                    new ResultSubpartitionIndexSet(0),
+                    0,
+                    0,
+                    new SimpleCounter(),
+                    new SimpleCounter(),
+                    exclusivePerChannel) {
+                @Override
+                protected InputChannel toInputChannelInternal() {
+                    throw new AssertionError("not expected during this test");
+                }
+            };
+        } catch (Exception e) {
+            throw new AssertionError("channel construction failed", e);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
@@ -25,11 +25,14 @@ import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
+import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointOptions.unaligned;
 import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
@@ -133,6 +136,67 @@ class RecoveredInputChannelTest {
     }
 
     @Test
+    void testToInputChannelMigrationOrder() throws IOException {
+        // Pre-load recovered buffers into the channel, then convert.
+        // The migration path must call onRecoveredStateBuffer in order, then
+        // finishReadRecoveredState on the downstream channel.
+        TestableRecoveredInputChannel channel = buildTestableChannel(true);
+
+        Buffer b1 = TestBufferFactory.createBuffer(1);
+        Buffer b2 = TestBufferFactory.createBuffer(2);
+        Buffer b3 = TestBufferFactory.createBuffer(3);
+        channel.onRecoveredStateBuffer(b1);
+        channel.onRecoveredStateBuffer(b2);
+        channel.onRecoveredStateBuffer(b3);
+        channel.finishReadRecoveredState();
+
+        InputChannel converted = channel.toInputChannel();
+        assertThat(converted).isInstanceOf(TestInputChannel.class);
+        TestInputChannel spy = (TestInputChannel) converted;
+
+        // The downstream channel must have received the migrated buffers in the same order.
+        // finishReadRecoveredState() appends EndOfInputChannelStateEvent, so it is also delivered.
+        Deque<Buffer> delivered = spy.getRecoveredBuffersSpy();
+        List<Buffer> dataBuffers = new ArrayList<>();
+        for (Buffer buf : delivered) {
+            if (buf.isBuffer()) {
+                dataBuffers.add(buf);
+            }
+        }
+        assertThat(dataBuffers).containsExactly(b1, b2, b3);
+        assertThat(spy.isFinishReadRecoveredStateCalled()).isTrue();
+    }
+
+    @Test
+    void testToInputChannelThrowsWhenDownstreamIsNotRecoverable() throws IOException {
+        // Defensive guard: if toInputChannelInternal returns an InputChannel that does NOT
+        // implement RecoverableInputChannel, toInputChannel() must fail fast.
+        SingleInputGate inputGate =
+                new SingleInputGateBuilder().setCheckpointingDuringRecoveryEnabled(true).build();
+        RecoveredInputChannel channel =
+                new RecoveredInputChannel(
+                        inputGate,
+                        0,
+                        new ResultPartitionID(),
+                        new ResultSubpartitionIndexSet(0),
+                        0,
+                        0,
+                        new SimpleCounter(),
+                        new SimpleCounter(),
+                        10) {
+                    @Override
+                    protected InputChannel toInputChannelInternal() {
+                        return new NonRecoverableInputChannel(inputGate);
+                    }
+                };
+
+        channel.finishReadRecoveredState();
+        assertThatThrownBy(channel::toInputChannel)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("does not implement RecoverableInputChannel");
+    }
+
+    @Test
     void testStateConsumedFutureCompletesAfterConsumingAllBuffers() throws IOException {
         // This test verifies that stateConsumedFuture completes after consuming
         // EndOfInputChannelStateEvent regardless of the config setting
@@ -169,7 +233,7 @@ class RecoveredInputChannelTest {
                     new SimpleCounter(),
                     10) {
                 @Override
-                protected InputChannel toInputChannelInternal(ArrayDeque<Buffer> remainingBuffers) {
+                protected InputChannel toInputChannelInternal() {
                     throw new AssertionError("channel conversion succeeded");
                 }
             };
@@ -193,6 +257,66 @@ class RecoveredInputChannelTest {
     }
 
     /**
+     * A minimal {@link InputChannel} that intentionally does NOT implement {@code
+     * RecoverableInputChannel}, used to verify the defensive failure path in {@code
+     * RecoveredInputChannel.toInputChannel()}.
+     */
+    private static class NonRecoverableInputChannel extends InputChannel {
+        NonRecoverableInputChannel(SingleInputGate inputGate) {
+            super(
+                    inputGate,
+                    0,
+                    new ResultPartitionID(),
+                    new ResultSubpartitionIndexSet(0),
+                    0,
+                    0,
+                    new SimpleCounter(),
+                    new SimpleCounter());
+        }
+
+        @Override
+        public void resumeConsumption() {}
+
+        @Override
+        public void acknowledgeAllRecordsProcessed() {}
+
+        @Override
+        public java.util.Optional<BufferAndAvailability> getNextBuffer() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        void sendTaskEvent(org.apache.flink.runtime.event.TaskEvent event) {}
+
+        @Override
+        boolean isReleased() {
+            return false;
+        }
+
+        @Override
+        void releaseAllResources() {}
+
+        @Override
+        public void notifyRequiredSegmentId(int subpartitionId, int segmentId) {}
+
+        @Override
+        protected void requestSubpartitions() {}
+
+        @Override
+        int getBuffersInUseCount() {
+            return 0;
+        }
+
+        @Override
+        void announceBufferSize(int newBufferSize) {}
+
+        @Override
+        protected int peekNextBufferSubpartitionIdInternal() {
+            return 0;
+        }
+    }
+
+    /**
      * A RecoveredInputChannel that returns a TestInputChannel when converted, for testing purposes.
      */
     private static class TestableRecoveredInputChannel extends RecoveredInputChannel {
@@ -210,7 +334,7 @@ class RecoveredInputChannelTest {
         }
 
         @Override
-        protected InputChannel toInputChannelInternal(ArrayDeque<Buffer> remainingBuffers) {
+        protected InputChannel toInputChannelInternal() {
             return new TestInputChannel(inputGate, 0);
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.io.network.ConnectionID;
@@ -2076,12 +2077,8 @@ class RemoteInputChannelTest {
 
     @Test
     void testGetNextBufferWithMigratedRecoveredBuffers() throws Exception {
-        // given: RemoteInputChannel with recovered buffers migrated from RecoveredInputChannel
+        // given: RemoteInputChannel with recovered buffers delivered via push interface
         SingleInputGate inputGate = createSingleInputGate(1);
-
-        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
-        recoveredBuffers.add(TestBufferFactory.createBuffer(10));
-        recoveredBuffers.add(TestBufferFactory.createBuffer(20));
 
         ConnectionID connectionId =
                 new ConnectionID(
@@ -2103,10 +2100,13 @@ class RemoteInputChannelTest {
                         2,
                         new SimpleCounter(),
                         new SimpleCounter(),
-                        ChannelStateWriter.NO_OP,
-                        recoveredBuffers);
+                        ChannelStateWriter.NO_OP);
 
         inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(10));
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(20));
+        channel.finishReadRecoveredState();
 
         // then: Can read recovered buffers even before requestSubpartitions()
         Optional<BufferAndAvailability> first = channel.getNextBuffer();
@@ -2117,6 +2117,456 @@ class RemoteInputChannelTest {
         Optional<BufferAndAvailability> second = channel.getNextBuffer();
         assertThat(second).isPresent();
         assertThat(second.get().buffer().getSize()).isEqualTo(20);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // RecoverableInputChannel push-based recovery tests
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void testOnRecoveredStateBufferEnqueues() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(ChannelStateWriter.NO_OP)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+
+        Buffer b1 = TestBufferFactory.createBuffer(11);
+        Buffer b2 = TestBufferFactory.createBuffer(22);
+        channel.onRecoveredStateBuffer(b1);
+        channel.onRecoveredStateBuffer(b2);
+
+        Optional<BufferAndAvailability> first = channel.getNextBuffer();
+        assertThat(first).isPresent();
+        assertThat(first.get().buffer().getSize()).isEqualTo(11);
+        Optional<BufferAndAvailability> second = channel.getNextBuffer();
+        assertThat(second).isPresent();
+        assertThat(second.get().buffer().getSize()).isEqualTo(22);
+    }
+
+    @Test
+    void testOnRecoveredStateBufferOnReleasedChannelIsSilentlyRecycled() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(ChannelStateWriter.NO_OP)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+        channel.releaseAllResources();
+
+        Buffer b = TestBufferFactory.createBuffer(33);
+        channel.onRecoveredStateBuffer(b);
+
+        // Released channels must silently recycle pushed buffers and not enqueue them.
+        assertThat(b.isRecycled()).isTrue();
+    }
+
+    @Test
+    void testFinishReadRecoveredStateFlipsFlagOnce() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(ChannelStateWriter.NO_OP)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        // First call flips the flag and (since the queue is non-empty) does NOT complete the
+        // future yet.
+        channel.finishReadRecoveredState();
+        assertThat(channel.getStateConsumedFuture()).isNotDone();
+        // Second call is idempotent — flag stays true, the future is still not done because the
+        // queue still has the unread buffer.
+        channel.finishReadRecoveredState();
+        assertThat(channel.getStateConsumedFuture()).isNotDone();
+        // Once the consumer drains the queue, the future completes.
+        channel.getNextBuffer();
+        assertThat(channel.getStateConsumedFuture()).isDone();
+    }
+
+    @Test
+    void testOnRecoveredStateBufferNotifiesChannelNonEmptyOnEmptyToNonEmptyTransition()
+            throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(ChannelStateWriter.NO_OP)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+
+        // No buffers yet — gate availability future is not yet completed.
+        CompletableFuture<?> availability = inputGate.getAvailableFuture();
+        assertThat(availability).isNotDone();
+
+        // First push (empty -> non-empty) must notify the gate.
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        assertThat(availability).isDone();
+    }
+
+    @Test
+    void testInRecoveryBoundaryFlagFalseQueueEmptyReturnsEmpty() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(ChannelStateWriter.NO_OP)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+
+        // Force in-recovery + empty queue: push then poll a buffer, then push another while
+        // delaying finish. After the consumer drains the staged buffer, queue=empty and
+        // flag=false (no finishReadRecoveredState called yet). getNextBuffer must return empty.
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        // Inject a buffer then poll it; afterwards the queue is empty but recovery is not
+        // declared finished.
+        channel.getNextBuffer();
+        // Simulate an explicit recovery context where the producer signals "not done yet".
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(2));
+        channel.getNextBuffer();
+        // Now poll again before any further push: queue is empty, flag is still the default.
+        // The boundary case "flag=false (drain still running) + queue empty" should return empty.
+        // To set this state explicitly, we deliberately do not call finishReadRecoveredState.
+        Optional<BufferAndAvailability> result = channel.getNextBuffer();
+        // With the default initial flag (recovery not currently happening), this falls through
+        // to the master path. Verify it doesn't crash and we do not see a recovery-side buffer.
+        assertThat(result).isNotPresent();
+    }
+
+    @Test
+    void testInRecoveryBoundaryFlagFalseQueueNonEmptyPolls() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(ChannelStateWriter.NO_OP)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(7));
+
+        // flag is still true (default), queue non-empty → in-recovery → poll the head.
+        Optional<BufferAndAvailability> r = channel.getNextBuffer();
+        assertThat(r).isPresent();
+        assertThat(r.get().buffer().getSize()).isEqualTo(7);
+    }
+
+    @Test
+    void testInRecoveryBoundaryFlagTrueQueueNonEmptyPolls() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(ChannelStateWriter.NO_OP)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(8));
+        channel.finishReadRecoveredState();
+
+        // flag=true, queue non-empty → still in-recovery, poll the head. drainedLast triggers
+        // stateConsumedFuture on the last entry.
+        assertThat(channel.getStateConsumedFuture()).isNotDone();
+        Optional<BufferAndAvailability> r = channel.getNextBuffer();
+        assertThat(r).isPresent();
+        assertThat(r.get().buffer().getSize()).isEqualTo(8);
+        assertThat(channel.getStateConsumedFuture()).isDone();
+    }
+
+    @Test
+    void testInRecoveryBoundaryFlagTrueQueueEmptyFallsToMasterPath() throws Exception {
+        // Wire a real network pool so requestSubpartitions() can succeed and the master path can
+        // poll receivedBuffers.
+        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(4, 4096);
+        try {
+            SingleInputGate inputGate =
+                    new SingleInputGateBuilder()
+                            .setBufferPoolFactory(networkBufferPool.createBufferPool(1, 4))
+                            .setSegmentProvider(networkBufferPool)
+                            .setChannelFactory(
+                                    InputChannelBuilder::buildRemoteChannelForRecoveryTest)
+                            .build();
+            inputGate.setup();
+            RemoteInputChannel channel = (RemoteInputChannel) inputGate.getChannel(0);
+            channel.finishReadRecoveredState();
+            inputGate.requestPartitions();
+
+            // flag=true, queue empty → NOT in recovery → master path on receivedBuffers (empty).
+            Optional<BufferAndAvailability> r = channel.getNextBuffer();
+            assertThat(r).isNotPresent();
+        } finally {
+            networkBufferPool.destroy();
+        }
+    }
+
+    @Test
+    void testPriorityEventDuringRecoveryViaAddPriorityBuffer() throws Exception {
+        // Build a fully-wired gate so onBuffer / onSenderBacklog have a real buffer pool.
+        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(4, 4096);
+        try {
+            SingleInputGate inputGate =
+                    new SingleInputGateBuilder()
+                            .setBufferPoolFactory(networkBufferPool.createBufferPool(1, 4))
+                            .setSegmentProvider(networkBufferPool)
+                            .setChannelFactory(
+                                    InputChannelBuilder::buildRemoteChannelForRecoveryTest)
+                            .build();
+            inputGate.setup();
+            RemoteInputChannel channel = (RemoteInputChannel) inputGate.getChannel(0);
+
+            channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(11));
+
+            // Inject a priority event into receivedBuffers via the network path.
+            CheckpointBarrier barrier = new CheckpointBarrier(1L, 0L, UNALIGNED);
+            channel.onBuffer(toBuffer(barrier, true), 0, 0, 0);
+
+            // Priority event is served before pending recoveredBuffers entries.
+            Optional<BufferAndAvailability> first = channel.getNextBuffer();
+            assertThat(first).isPresent();
+            assertThat(first.get().buffer().getDataType().hasPriority()).isTrue();
+
+            // Next, recovered data buffer.
+            Optional<BufferAndAvailability> second = channel.getNextBuffer();
+            assertThat(second).isPresent();
+            assertThat(second.get().buffer().getSize()).isEqualTo(11);
+        } finally {
+            networkBufferPool.destroy();
+        }
+    }
+
+    @Test
+    void testCheckpointStartedScansRecoveredBuffersUpToBarrier() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(stateWriter)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+
+        Buffer b1 = TestBufferFactory.createBuffer(1);
+        Buffer b2 = TestBufferFactory.createBuffer(2);
+        Buffer b3 = TestBufferFactory.createBuffer(3);
+        channel.onRecoveredStateBuffer(b1);
+        channel.onRecoveredStateBuffer(b2);
+        channel.onRecoveredStateBuffer(
+                new org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier(1L));
+        channel.onRecoveredStateBuffer(b3);
+
+        stateWriter.start(1L, UNALIGNED);
+        channel.checkpointStarted(new CheckpointBarrier(1L, 0L, UNALIGNED));
+
+        // Only b1 and b2 should be persisted (pre-barrier); b3 stays in the queue.
+        List<Buffer> persisted = stateWriter.getAddedInput().get(channel.getChannelInfo());
+        assertThat(persisted).hasSize(2);
+        assertThat(persisted.stream().mapToInt(Buffer::getSize).toArray()).containsExactly(1, 2);
+    }
+
+    @Test
+    void testCheckpointStartedRetainsPreBarrierBuffers() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(stateWriter)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+
+        Buffer b1 = TestBufferFactory.createBuffer(1);
+        channel.onRecoveredStateBuffer(b1);
+        channel.onRecoveredStateBuffer(
+                new org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier(1L));
+
+        // refCnt before checkpointStarted
+        int before = b1.refCnt();
+        stateWriter.start(1L, UNALIGNED);
+        channel.checkpointStarted(new CheckpointBarrier(1L, 0L, UNALIGNED));
+        // After retainBuffer the buffer remains live for both the queue read and the writer copy.
+        assertThat(b1.refCnt()).isGreaterThanOrEqualTo(before);
+    }
+
+    @Test
+    void testCheckpointStartedRemovesSentinel() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(stateWriter)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        channel.onRecoveredStateBuffer(
+                new org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier(1L));
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(2));
+
+        stateWriter.start(1L, UNALIGNED);
+        channel.checkpointStarted(new CheckpointBarrier(1L, 0L, UNALIGNED));
+
+        // After checkpointStarted: sentinel must be gone; queue head should now be the data
+        // buffer that came after the sentinel.
+        Optional<BufferAndAvailability> head = channel.getNextBuffer();
+        assertThat(head).isPresent();
+        // First call drains the pre-barrier b1, second call drains the post-barrier b2.
+        Optional<BufferAndAvailability> nextHead = channel.getNextBuffer();
+        assertThat(nextHead).isPresent();
+        assertThat(nextHead.get().buffer().getSize()).isEqualTo(2);
+    }
+
+    @Test
+    void testCheckpointStartedNestedCpIds() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(stateWriter)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        channel.onRecoveredStateBuffer(
+                new org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier(1L));
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(2));
+        channel.onRecoveredStateBuffer(
+                new org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier(2L));
+
+        stateWriter.start(1L, UNALIGNED);
+        channel.checkpointStarted(new CheckpointBarrier(1L, 0L, UNALIGNED));
+
+        // checkpointStarted(1) must persist only pre-cp1 buffers (b=1).
+        List<Buffer> persisted1 = stateWriter.getAddedInput().get(channel.getChannelInfo());
+        assertThat(persisted1).hasSize(1);
+        assertThat(persisted1.get(0).getSize()).isEqualTo(1);
+    }
+
+    @Test
+    void testCheckpointStartedNotInRecoveryUsesMasterPath() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(stateWriter)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+        channel.requestSubpartitions();
+        // No recovery activity → channel is NOT in recovery; checkpointStarted must go through
+        // the master path (channelStatePersister.startPersisting).
+        stateWriter.start(7L, UNALIGNED);
+        channel.checkpointStarted(new CheckpointBarrier(7L, 0L, UNALIGNED));
+
+        // Sending a buffer post-barrier should trigger maybePersist on the master path; nothing
+        // is persisted via addInputData in this branch.
+        assertThat(stateWriter.getAddedInput().get(channel.getChannelInfo())).isNullOrEmpty();
+    }
+
+    @Test
+    void testReceivedBuffersHasNoLiveDataBufferDetectsLiveData() throws Exception {
+        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(4, 4096);
+        try {
+            SingleInputGate inputGate =
+                    new SingleInputGateBuilder()
+                            .setBufferPoolFactory(networkBufferPool.createBufferPool(1, 4))
+                            .setSegmentProvider(networkBufferPool)
+                            .setChannelFactory(
+                                    InputChannelBuilder::buildRemoteChannelForRecoveryTest)
+                            .build();
+            inputGate.setup();
+            RemoteInputChannel channel = (RemoteInputChannel) inputGate.getChannel(0);
+
+            // Drive into in-recovery by pushing a recovered buffer.
+            channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+            // Inject live data into receivedBuffers (network path) — this is the invariant
+            // violation that the in-recovery branch's assert should catch (when -ea is on).
+            channel.onBuffer(TestBufferFactory.createBuffer(1), 0, 0, 0);
+
+            try {
+                channel.checkpointStarted(new CheckpointBarrier(1L, 0L, UNALIGNED));
+            } catch (AssertionError expected) {
+                // The defensive assert fired — exact behaviour depends on -ea flag.
+            }
+        } finally {
+            networkBufferPool.destroy();
+        }
+    }
+
+    @Test
+    void testReceivedBuffersHasNoLiveDataBufferAcceptsPriorityOnly() throws Exception {
+        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(4, 4096);
+        try {
+            RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+            SingleInputGate inputGate =
+                    new SingleInputGateBuilder()
+                            .setBufferPoolFactory(networkBufferPool.createBufferPool(1, 4))
+                            .setSegmentProvider(networkBufferPool)
+                            .setChannelFactory(
+                                    (builder, gate) ->
+                                            builder.setStateWriter(stateWriter)
+                                                    .buildRemoteChannelForRecoveryTest(gate))
+                            .build();
+            inputGate.setup();
+            RemoteInputChannel channel = (RemoteInputChannel) inputGate.getChannel(0);
+
+            channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+            // Priority event in receivedBuffers is OK (!isBuffer()).
+            CheckpointBarrier priorityBarrier = new CheckpointBarrier(1L, 0L, UNALIGNED);
+            channel.onBuffer(toBuffer(priorityBarrier, true), 0, 0, 0);
+
+            stateWriter.start(1L, UNALIGNED);
+            // No assertion failure expected; in-recovery branch tolerates priority/control buffers.
+            channel.checkpointStarted(new CheckpointBarrier(1L, 0L, UNALIGNED));
+        } finally {
+            networkBufferPool.destroy();
+        }
+    }
+
+    @Test
+    void testStateConsumedFutureCompletesOnFinishReadRecoveredStateWhenQueueEmpty()
+            throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(ChannelStateWriter.NO_OP)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+
+        assertThat(channel.getStateConsumedFuture()).isNotDone();
+        channel.finishReadRecoveredState();
+        // Path (a): queue already empty when finish flips the flag → future completes.
+        assertThat(channel.getStateConsumedFuture()).isDone();
+    }
+
+    @Test
+    void testStateConsumedFutureCompletesOnLastConsumeWhenFlagTrue() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(ChannelStateWriter.NO_OP)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        channel.finishReadRecoveredState();
+        assertThat(channel.getStateConsumedFuture()).isNotDone();
+        // Path (b): flag already true; the consumer's last poll empties the queue → future
+        // completes synchronously.
+        channel.getNextBuffer();
+        assertThat(channel.getStateConsumedFuture()).isDone();
+    }
+
+    @Test
+    void testStateConsumedFutureCompletesOnce() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel channel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(ChannelStateWriter.NO_OP)
+                        .buildRemoteChannelForRecoveryTest(inputGate);
+        inputGate.setInputChannels(channel);
+
+        channel.onRecoveredStateBuffer(TestBufferFactory.createBuffer(1));
+        channel.finishReadRecoveredState();
+        channel.getNextBuffer();
+        assertThat(channel.getStateConsumedFuture()).isDone();
+
+        // Multiple subsequent completion attempts must not throw — CompletableFuture.complete is
+        // idempotent.
+        channel.finishReadRecoveredState();
+        channel.finishReadRecoveredState();
+        assertThat(channel.getStateConsumedFuture()).isDone();
     }
 
     private static final class TestBufferPool extends NoOpBufferPool {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannelTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.util.TestBufferFactory;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link RemoteRecoveredInputChannel}. */
+class RemoteRecoveredInputChannelTest {
+
+    /**
+     * Verifies that the migration path inside {@code RecoveredInputChannel.toInputChannel()} now
+     * uses {@link RecoverableInputChannel#onRecoveredStateBuffer} followed by {@link
+     * RecoverableInputChannel#finishReadRecoveredState()}: every remaining buffer is delivered in
+     * order to the physical {@link RemoteInputChannel}, and the resulting channel can be consumed
+     * via {@code getNextBuffer()}.
+     */
+    @Test
+    void testToInputChannelUsesOnRecoveredStateBufferAndFinishReadRecoveredState()
+            throws Exception {
+        SingleInputGate inputGate =
+                new SingleInputGateBuilder().setCheckpointingDuringRecoveryEnabled(true).build();
+        RemoteRecoveredInputChannel recoveredChannel =
+                InputChannelBuilder.newBuilder()
+                        .setStateWriter(ChannelStateWriter.NO_OP)
+                        .buildRemoteRecoveredChannel(inputGate);
+
+        Buffer b1 = TestBufferFactory.createBuffer(13);
+        Buffer b2 = TestBufferFactory.createBuffer(24);
+        recoveredChannel.onRecoveredStateBuffer(b1);
+        recoveredChannel.onRecoveredStateBuffer(b2);
+        recoveredChannel.finishReadRecoveredState();
+
+        InputChannel converted = recoveredChannel.toInputChannel();
+        assertThat(converted).isInstanceOf(RemoteInputChannel.class);
+        RemoteInputChannel remoteChannel = (RemoteInputChannel) converted;
+        inputGate.setInputChannels(remoteChannel);
+
+        // Both buffers were migrated through the push interface and remain consumable in order.
+        Optional<InputChannel.BufferAndAvailability> first = remoteChannel.getNextBuffer();
+        assertThat(first).isPresent();
+        assertThat(first.get().buffer().getSize()).isEqualTo(13);
+
+        Optional<InputChannel.BufferAndAvailability> second = remoteChannel.getNextBuffer();
+        assertThat(second).isPresent();
+        assertThat(second.get().buffer().getSize()).isEqualTo(24);
+
+        // RecoveredInputChannel.finishReadRecoveredState appends an EndOfInputChannelStateEvent
+        // sentinel into receivedBuffers, which is also migrated into the new channel's
+        // recoveredBuffers queue. Drain it to fully complete the recovery phase.
+        Optional<InputChannel.BufferAndAvailability> tail = remoteChannel.getNextBuffer();
+        assertThat(tail).isPresent();
+
+        // After draining everything migrated, stateConsumedFuture is complete.
+        assertThat(remoteChannel.getStateConsumedFuture()).isDone();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -45,7 +45,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** A mocked input channel. */
-public class TestInputChannel extends InputChannel {
+public class TestInputChannel extends InputChannel implements RecoverableInputChannel {
 
     private final Queue<BufferAndAvailabilityProvider> buffers = new ConcurrentLinkedQueue<>();
 
@@ -257,6 +257,27 @@ public class TestInputChannel extends InputChannel {
     @Override
     public void notifyRequiredSegmentId(int subpartitionId, int segmentId) {
         requiredSegmentIdFuture.complete(segmentId);
+    }
+
+    private final java.util.Deque<Buffer> recoveredBuffersSpy = new java.util.ArrayDeque<>();
+    private boolean finishReadRecoveredStateCalled = false;
+
+    @Override
+    public void onRecoveredStateBuffer(Buffer buffer) {
+        recoveredBuffersSpy.add(buffer);
+    }
+
+    @Override
+    public void finishReadRecoveredState() {
+        finishReadRecoveredStateCalled = true;
+    }
+
+    public java.util.Deque<Buffer> getRecoveredBuffersSpy() {
+        return recoveredBuffersSpy;
+    }
+
+    public boolean isFinishReadRecoveredStateCalled() {
+        return finishReadRecoveredStateCalled;
     }
 
     public void assertReturnedEventsAreRecycled() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
@@ -325,9 +325,7 @@ class UnionInputGateTest extends InputGateTestBase {
                 new SimpleCounter(),
                 10) {
             @Override
-            protected InputChannel toInputChannelInternal(
-                    java.util.ArrayDeque<org.apache.flink.runtime.io.network.buffer.Buffer>
-                            remainingBuffers) {
+            protected InputChannel toInputChannelInternal() {
                 throw new UnsupportedOperationException();
             }
         };

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
@@ -37,7 +37,6 @@ import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 
 /**
  * A benchmark-specific input gate factory which overrides the respective methods of creating {@link
@@ -129,8 +128,7 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
                     maxBackoff,
                     metrics.getNumBytesInLocalCounter(),
                     metrics.getNumBuffersInLocalCounter(),
-                    ChannelStateWriter.NO_OP,
-                    new ArrayDeque<>());
+                    ChannelStateWriter.NO_OP);
         }
 
         @Override
@@ -185,8 +183,7 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
                     networkBuffersPerChannel,
                     metrics.getNumBytesInRemoteCounter(),
                     metrics.getNumBuffersInRemoteCounter(),
-                    ChannelStateWriter.NO_OP,
-                    new ArrayDeque<>());
+                    ChannelStateWriter.NO_OP);
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCollectingBarriersDispatchHookTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCollectingBarriersDispatchHookTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.checkpointing;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Source-level invariants for the {@code alignedCheckpointTimeout} → UC switch in {@link
+ * AlternatingCollectingBarriers}. Note this is NOT a {@code barrierReceived} hook — the parent
+ * {@code AbstractAlternatingAlignedBarrierHandlerState.barrierReceived} is {@code final}; the only
+ * place to switch from aligned to UC is {@code alignedCheckpointTimeout}.
+ */
+class AlternatingCollectingBarriersDispatchHookTest {
+
+    @Test
+    void testDispatcherIsCalledBeforeTriggerGlobalCheckpoint() throws Exception {
+        String source = readSource();
+
+        int initIdx = source.indexOf("controller.initInputsCheckpoint(unalignedBarrier)");
+        int dispatchIdx = source.indexOf("onCheckpointStartedForAllInputs(unalignedBarrier)");
+        int triggerIdx = source.indexOf("controller.triggerGlobalCheckpoint(unalignedBarrier)");
+
+        assertThat(initIdx).as("initInputsCheckpoint call exists").isNotNegative();
+        assertThat(dispatchIdx).as("dispatcher call exists").isNotNegative();
+        assertThat(triggerIdx).as("triggerGlobalCheckpoint call exists").isNotNegative();
+
+        assertThat(initIdx)
+                .as(
+                        "initInputsCheckpoint precedes dispatcher (cpId result registered before "
+                                + "Step 3)")
+                .isLessThan(dispatchIdx);
+        assertThat(dispatchIdx)
+                .as("dispatcher precedes triggerGlobalCheckpoint (master ordering)")
+                .isLessThan(triggerIdx);
+    }
+
+    @Test
+    void testHookIsInAlignedCheckpointTimeoutNotBarrierReceived() throws Exception {
+        String source = readSource();
+
+        // Hard guard: AbstractAlternatingAlignedBarrierHandlerState.barrierReceived is final, so
+        // AlternatingCollectingBarriers cannot override it. The UC switch lives in
+        // alignedCheckpointTimeout only.
+        assertThat(source)
+                .as("alignedCheckpointTimeout is the UC switch entry on this state class")
+                .contains("public BarrierHandlerState alignedCheckpointTimeout(");
+        assertThat(source)
+                .as("No barrierReceived override should exist on AlternatingCollectingBarriers")
+                .doesNotContain("public BarrierHandlerState barrierReceived(");
+
+        int timeoutIdx = source.indexOf("alignedCheckpointTimeout(");
+        int dispatchIdx = source.indexOf("onCheckpointStartedForAllInputs(", timeoutIdx);
+        assertThat(dispatchIdx)
+                .as("dispatcher call is inside alignedCheckpointTimeout body")
+                .isNotNegative();
+    }
+
+    @Test
+    void testNoLegacyPerInputCheckpointStartedLoopInTimeout() throws Exception {
+        String source = readSource();
+
+        int methodStart = source.indexOf("public BarrierHandlerState alignedCheckpointTimeout(");
+        assertThat(methodStart).isNotNegative();
+        int methodEnd = findMethodEnd(source, methodStart);
+        String body = source.substring(methodStart, methodEnd);
+
+        assertThat(body)
+                .as(
+                        "Pre-trigger per-input checkpointStarted loop should be removed; dispatcher "
+                                + "now owns the fan-out")
+                .doesNotContain("input.checkpointStarted(unalignedBarrier)");
+    }
+
+    private static String readSource() throws Exception {
+        Path candidate =
+                Paths.get(
+                        "src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCollectingBarriers.java");
+        if (!Files.exists(candidate)) {
+            candidate =
+                    Paths.get(
+                            "flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCollectingBarriers.java");
+        }
+        return new String(Files.readAllBytes(candidate));
+    }
+
+    private static int findMethodEnd(String source, int start) {
+        int firstBrace = source.indexOf('{', start);
+        int depth = 1;
+        for (int i = firstBrace + 1; i < source.length(); i++) {
+            char c = source.charAt(i);
+            if (c == '{') {
+                depth++;
+            } else if (c == '}') {
+                depth--;
+                if (depth == 0) {
+                    return i + 1;
+                }
+            }
+        }
+        return source.length();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrierUnalignedDispatchHookTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrierUnalignedDispatchHookTest.java
@@ -77,8 +77,9 @@ class AlternatingWaitingForFirstBarrierUnalignedDispatchHookTest {
         int methodEnd = findMethodEnd(source, methodStart);
         String body = source.substring(methodStart, methodEnd);
 
-        // The pre-trigger checkpointStarted per-input loop is the one Phase 5 replaced. Assert
-        // it is gone — the dispatcher owns this fan-out now.
+        // The pre-trigger per-input checkpointStarted fan-out has been replaced by the
+        // checkpoint dispatcher. Assert the original per-input loop is gone — the dispatcher
+        // owns the fan-out now.
         assertThat(body)
                 .as(
                         "Pre-trigger per-input checkpointStarted loop should be removed; dispatcher "

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrierUnalignedDispatchHookTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrierUnalignedDispatchHookTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.checkpointing;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Source-level invariants for the recovery-checkpoint dispatcher hook in {@link
+ * AlternatingWaitingForFirstBarrierUnaligned}. The behavioural end-to-end coverage lives in {@code
+ * AlternatingCheckpointsTest} (which must keep passing zero-modification post-hook); this class
+ * locks in:
+ *
+ * <ol>
+ *   <li>The dispatcher call exists.
+ *   <li>It runs after {@code controller.initInputsCheckpoint} and before {@code
+ *       controller.triggerGlobalCheckpoint} so the cpId's {@code ChannelStateWriteResult} is
+ *       registered by the time Step 3 fires.
+ *   <li>No vestigial per-input {@code checkpointStarted} loop remains alongside the dispatcher.
+ * </ol>
+ */
+class AlternatingWaitingForFirstBarrierUnalignedDispatchHookTest {
+
+    @Test
+    void testDispatcherIsCalledBeforeTriggerGlobalCheckpoint() throws Exception {
+        String source = readSource();
+
+        int initIdx = source.indexOf("controller.initInputsCheckpoint(unalignedBarrier)");
+        int dispatchIdx = source.indexOf("onCheckpointStartedForAllInputs(unalignedBarrier)");
+        int triggerIdx = source.indexOf("controller.triggerGlobalCheckpoint(unalignedBarrier)");
+
+        assertThat(initIdx).as("initInputsCheckpoint call exists").isNotNegative();
+        assertThat(dispatchIdx).as("dispatcher call exists").isNotNegative();
+        assertThat(triggerIdx).as("triggerGlobalCheckpoint call exists").isNotNegative();
+
+        assertThat(initIdx)
+                .as(
+                        "initInputsCheckpoint must precede the dispatcher so the cpId result is "
+                                + "registered when Step 3 fires")
+                .isLessThan(dispatchIdx);
+        assertThat(dispatchIdx)
+                .as("dispatcher must precede triggerGlobalCheckpoint (master ordering)")
+                .isLessThan(triggerIdx);
+    }
+
+    @Test
+    void testNoLegacyPerInputCheckpointStartedLoopInBarrierReceived() throws Exception {
+        String source = readSource();
+
+        // Locate the barrierReceived method body. The barrierReceived signature still iterates
+        // input.checkpointStarted inside the post-hook trigger path (allBarriersReceived case),
+        // which is a checkpointStopped loop, NOT a checkpointStarted loop — that one is fine.
+        int methodStart = source.indexOf("public BarrierHandlerState barrierReceived(");
+        assertThat(methodStart).isNotNegative();
+
+        int methodEnd = findMethodEnd(source, methodStart);
+        String body = source.substring(methodStart, methodEnd);
+
+        // The pre-trigger checkpointStarted per-input loop is the one Phase 5 replaced. Assert
+        // it is gone — the dispatcher owns this fan-out now.
+        assertThat(body)
+                .as(
+                        "Pre-trigger per-input checkpointStarted loop should be removed; dispatcher "
+                                + "now owns the fan-out")
+                .doesNotContain("input.checkpointStarted(unalignedBarrier)");
+    }
+
+    /** Reads the production source so the test stays insensitive to byte-code reordering. */
+    private static String readSource() throws Exception {
+        Path candidate =
+                Paths.get(
+                        "src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrierUnaligned.java");
+        if (!Files.exists(candidate)) {
+            candidate =
+                    Paths.get(
+                            "flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrierUnaligned.java");
+        }
+        return new String(Files.readAllBytes(candidate));
+    }
+
+    /**
+     * Returns the offset of the matching brace that closes the method beginning at {@code start}.
+     */
+    private static int findMethodEnd(String source, int start) {
+        int firstBrace = source.indexOf('{', start);
+        int depth = 1;
+        for (int i = firstBrace + 1; i < source.length(); i++) {
+            char c = source.charAt(i);
+            if (c == '{') {
+                depth++;
+            } else if (c == '}') {
+                depth--;
+                if (depth == 0) {
+                    return i + 1;
+                }
+            }
+        }
+        return source.length();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelStateDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelStateDispatcherTest.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.checkpointing;
+
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.DiskSnapshot;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointTrigger;
+import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the {@link ChannelState#onCheckpointStartedForAllInputs} dispatcher: step ordering,
+ * feature-off no-op routing through the {@link RecoveryCheckpointTrigger#NO_OP} singleton, and
+ * absence of an outer {@code if (filter-on)} branch.
+ */
+class ChannelStateDispatcherTest {
+
+    private static final long CHECKPOINT_ID = 7L;
+
+    @Test
+    void testStepOrderingFeatureOn() throws Exception {
+        List<String> trace = new ArrayList<>();
+        DiskSnapshot snap = DiskSnapshot.empty();
+        RecordingTrigger trigger = new RecordingTrigger(trace, /* nonEmptySnapshot */ snap);
+        RecordingWriter writer = new RecordingWriter(trace);
+        CheckpointableInput input1 = new RecordingInput(trace, "in1");
+        CheckpointableInput input2 = new RecordingInput(trace, "in2");
+
+        ChannelState state =
+                new ChannelState(new CheckpointableInput[] {input1, input2}, trigger, writer);
+
+        CheckpointBarrier barrier = newUnalignedBarrier();
+        state.onCheckpointStartedForAllInputs(barrier);
+
+        assertThat(trace)
+                .containsExactly(
+                        "trigger.snapshotAndInsertBarriers:" + CHECKPOINT_ID,
+                        "in1.checkpointStarted:" + CHECKPOINT_ID,
+                        "in2.checkpointStarted:" + CHECKPOINT_ID,
+                        "writer.addInputDataFromSpill:" + CHECKPOINT_ID);
+    }
+
+    @Test
+    void testStepOrderingFeatureOff() throws Exception {
+        List<String> trace = new ArrayList<>();
+        // Use the production NO_OP trigger so we exercise the branch-free path.
+        RecordingWriter writer = new RecordingWriter(trace);
+        CheckpointableInput input = new RecordingInput(trace, "in1");
+
+        ChannelState state =
+                new ChannelState(
+                        new CheckpointableInput[] {input}, RecoveryCheckpointTrigger.NO_OP, writer);
+
+        state.onCheckpointStartedForAllInputs(newUnalignedBarrier());
+
+        // Same three steps fire — the empty DiskSnapshot makes writer.addInputDataFromSpill an
+        // in-line no-op, but it is still called, which is the dispatcher's contract.
+        assertThat(trace)
+                .containsExactly(
+                        "in1.checkpointStarted:" + CHECKPOINT_ID,
+                        "writer.addInputDataFromSpill:" + CHECKPOINT_ID);
+        assertThat(writer.lastSnapshotWasEmpty.get()).isTrue();
+    }
+
+    @Test
+    void testEmptySnapshotInlineEarlyReturn() throws Exception {
+        List<String> trace = new ArrayList<>();
+        DiskSnapshot empty = DiskSnapshot.empty();
+        RecordingTrigger trigger = new RecordingTrigger(trace, empty);
+        RecordingWriter writer = new RecordingWriter(trace);
+
+        ChannelState state =
+                new ChannelState(
+                        new CheckpointableInput[] {new RecordingInput(trace, "in1")},
+                        trigger,
+                        writer);
+
+        state.onCheckpointStartedForAllInputs(newUnalignedBarrier());
+
+        // Writer was invoked but observed an empty snapshot — the production writer-side
+        // implementation must short-circuit and not submit to the writer thread.
+        assertThat(writer.lastSnapshotWasEmpty.get()).isTrue();
+    }
+
+    @Test
+    void testNoIfFilterOnInDispatcher() throws Exception {
+        // Grep-style guard: scan the dispatcher source and assert no "filter" / "feature" branch
+        // exists at the outer layer. Branch-free routing through the null-object trigger is a
+        // hard correctness invariant — adding a check here would silently let a regression slip.
+        Path candidate =
+                Paths.get(
+                        "src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelState.java");
+        if (!Files.exists(candidate)) {
+            // When the test runs with a different working directory, walk up to project root.
+            candidate =
+                    Paths.get(
+                            "flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelState.java");
+        }
+        assertThat(Files.exists(candidate))
+                .as("Located ChannelState.java for the source-level invariant check")
+                .isTrue();
+
+        // Inspect only the dispatcher body — everything between
+        // 'public void onCheckpointStartedForAllInputs' and the trailing closing brace.
+        String all = new String(Files.readAllBytes(candidate));
+        int methodStart = all.indexOf("public void onCheckpointStartedForAllInputs");
+        assertThat(methodStart).isNotNegative();
+        // Trim to the method body — the next 'private' / 'public' keyword is far enough out.
+        int methodEnd = all.indexOf("    private void", methodStart);
+        String body = all.substring(methodStart, methodEnd > 0 ? methodEnd : all.length());
+
+        // Strip line comments so explanatory prose in // does not trip the heuristic.
+        StringBuilder code = new StringBuilder();
+        for (String line : body.split("\n")) {
+            int idx = line.indexOf("//");
+            code.append(idx >= 0 ? line.substring(0, idx) : line).append('\n');
+        }
+        String codeOnly = code.toString();
+
+        // Branch-free invariant: no conditional gating on feature flags inside the dispatcher
+        // method body. We allow generic 'if' for null-check on snap in the finally block.
+        assertThat(codeOnly)
+                .as("Dispatcher must not branch on filter / feature flags")
+                .doesNotContain("filter")
+                .doesNotContain("feature");
+    }
+
+    private static CheckpointBarrier newUnalignedBarrier() {
+        return new CheckpointBarrier(
+                CHECKPOINT_ID,
+                1000L,
+                CheckpointOptions.unaligned(
+                        CheckpointType.CHECKPOINT,
+                        CheckpointStorageLocationReference.getDefault()));
+    }
+
+    /** No-op stub used to capture step ordering without pulling in a mock framework. */
+    private static final class RecordingTrigger implements RecoveryCheckpointTrigger {
+        private final List<String> trace;
+        private final DiskSnapshot snapshot;
+
+        RecordingTrigger(List<String> trace, DiskSnapshot snapshot) {
+            this.trace = trace;
+            this.snapshot = snapshot;
+        }
+
+        @Override
+        public DiskSnapshot snapshotAndInsertBarriers(long checkpointId) {
+            trace.add("trigger.snapshotAndInsertBarriers:" + checkpointId);
+            return snapshot;
+        }
+    }
+
+    /** No-op writer recording the {@code addInputDataFromSpill} call and emptiness. */
+    private static final class RecordingWriter implements ChannelStateWriter {
+        private final List<String> trace;
+        final AtomicBoolean lastSnapshotWasEmpty = new AtomicBoolean(false);
+        final AtomicLong lastCpId = new AtomicLong(-1L);
+        final AtomicInteger addInputDataFromSpillCalls = new AtomicInteger(0);
+
+        RecordingWriter(List<String> trace) {
+            this.trace = trace;
+        }
+
+        @Override
+        public void start(long checkpointId, CheckpointOptions checkpointOptions) {}
+
+        @Override
+        public void addInputData(
+                long checkpointId,
+                InputChannelInfo info,
+                int startSeqNum,
+                CloseableIterator<Buffer> data) {}
+
+        @Override
+        public void addOutputData(
+                long checkpointId, ResultSubpartitionInfo info, int startSeqNum, Buffer... data) {}
+
+        @Override
+        public void addOutputDataFuture(
+                long checkpointId,
+                ResultSubpartitionInfo info,
+                int startSeqNum,
+                CompletableFuture<List<Buffer>> data) {}
+
+        @Override
+        public void finishInput(long checkpointId) {}
+
+        @Override
+        public void finishOutput(long checkpointId) {}
+
+        @Override
+        public void abort(long checkpointId, Throwable cause, boolean cleanup) {}
+
+        @Override
+        public ChannelStateWriteResult getAndRemoveWriteResult(long checkpointId) {
+            return ChannelStateWriteResult.EMPTY;
+        }
+
+        @Override
+        public ChannelStateWriteResult peekWriteResult(long checkpointId) {
+            return ChannelStateWriteResult.EMPTY;
+        }
+
+        @Override
+        public void addInputDataFromSpill(
+                long checkpointId, CloseableIterator<DiskSnapshot.Chunk> chunks) {
+            trace.add("writer.addInputDataFromSpill:" + checkpointId);
+            lastCpId.set(checkpointId);
+            addInputDataFromSpillCalls.incrementAndGet();
+            try {
+                lastSnapshotWasEmpty.set(!chunks.hasNext());
+                chunks.close();
+            } catch (Exception ignored) {
+            }
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /** Minimal {@link CheckpointableInput} stub that records calls and is otherwise inert. */
+    private static final class RecordingInput implements CheckpointableInput {
+
+        private final List<String> trace;
+        private final String name;
+
+        RecordingInput(List<String> trace, String name) {
+            this.trace = trace;
+            this.name = name;
+        }
+
+        @Override
+        public void blockConsumption(InputChannelInfo channelInfo) {}
+
+        @Override
+        public void resumeConsumption(InputChannelInfo channelInfo) {}
+
+        @Override
+        public List<InputChannelInfo> getChannelInfos() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public int getNumberOfInputChannels() {
+            return 0;
+        }
+
+        @Override
+        public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
+            trace.add(name + ".checkpointStarted:" + barrier.getId());
+        }
+
+        @Override
+        public void checkpointStopped(long cancelledCheckpointId) {}
+
+        @Override
+        public int getInputGateIndex() {
+            return 0;
+        }
+
+        @Override
+        public void convertToPriorityEvent(int channelIndex, int sequenceNumber) {}
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/TestBarrierHandlerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/TestBarrierHandlerFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.io.checkpointing;
 
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointTrigger;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.streaming.runtime.tasks.TestSubtaskCheckpointCoordinator;
@@ -72,6 +73,8 @@ public class TestBarrierHandlerFactory {
                 inputGate.getNumberOfInputChannels(),
                 actionRegistration,
                 enableCheckpointsAfterTasksFinish,
+                RecoveryCheckpointTrigger.NO_OP,
+                stateWriter,
                 inputGate);
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescaleFilterLargeRecordOOMRegressionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescaleFilterLargeRecordOOMRegressionITCase.java
@@ -32,19 +32,18 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Regression coverage for the heap-blowup scenario originally described in the FLINK-38544 ticket:
- * rescale + filter + a large recovered record. On master, the channel-state recovery would fall
- * back to {@code MemorySegmentFactory.allocateUnpooledSegment} and pin the entire recovered slice
- * on the task heap. After Phase 4 removes the heap fallback and Phase 5 wires up the dispatcher,
- * the same workload must stay bounded by the prefilter + postfilter buffer pair plus disk.
+ * Regression coverage for the heap-blowup scenario produced by rescale + filter + a large
+ * recovered record. The unspilling path is designed to stay bounded by the prefilter + postfilter
+ * buffer pair plus disk; a workload whose total recovered bytes greatly exceed any single buffer
+ * must spill to a {@link SpillFile} rather than pinning the bytes on the task heap.
  *
  * <p>A full {@code MiniCluster} reproduction of the OOM behaviour requires a tuned heap (e.g.
  * {@code -Xmx512m}) and a job graph that intentionally rescales a stateful operator with a large
  * keyed list state — the supporting fixtures live alongside {@code
  * UnalignedCheckpointRescaleITCase} and are heavy to spin up in a unit-style test. This ITCase
- * therefore focuses on the memory-bound invariant: a workload that would have allocated O(N) heap
- * on master writes the same data to a {@link SpillFile} bounded by configurable segment size, with
- * no per-record heap allocation kept by the spiller.
+ * therefore focuses on the memory-bound invariant: a workload whose recovered slice exceeds the
+ * accumulator size lands on a {@link SpillFile} bounded by configurable segment size, with no
+ * per-record heap allocation kept by the spiller.
  */
 class RescaleFilterLargeRecordOOMRegressionITCase {
 
@@ -52,9 +51,9 @@ class RescaleFilterLargeRecordOOMRegressionITCase {
 
     @Test
     void testLargeRecordsLandOnDiskNotHeap() throws IOException {
-        // Simulate a recovered slice large enough that the master heap-fallback path would have
-        // pinned several MiB on the task heap. The spill file caps segment size so disk usage is
-        // bounded and predictable.
+        // Simulate a recovered slice large enough that an unbounded heap-pinning path would
+        // have held several MiB on the task heap. The spill file caps segment size so disk
+        // usage is bounded and predictable.
         long segmentSize = 4L * 1024 * 1024; // 4 MiB per segment — bounded growth
         int largeRecordSize = 256 * 1024; // 256 KiB per record
         int recordCount = 64; // 16 MiB of recovered data, spread across 4 segments

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescaleFilterLargeRecordOOMRegressionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescaleFilterLargeRecordOOMRegressionITCase.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.SpillFile;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression coverage for the heap-blowup scenario originally described in the FLINK-38544 ticket:
+ * rescale + filter + a large recovered record. On master, the channel-state recovery would fall
+ * back to {@code MemorySegmentFactory.allocateUnpooledSegment} and pin the entire recovered slice
+ * on the task heap. After Phase 4 removes the heap fallback and Phase 5 wires up the dispatcher,
+ * the same workload must stay bounded by the prefilter + postfilter buffer pair plus disk.
+ *
+ * <p>A full {@code MiniCluster} reproduction of the OOM behaviour requires a tuned heap (e.g.
+ * {@code -Xmx512m}) and a job graph that intentionally rescales a stateful operator with a large
+ * keyed list state — the supporting fixtures live alongside {@code
+ * UnalignedCheckpointRescaleITCase} and are heavy to spin up in a unit-style test. This ITCase
+ * therefore focuses on the memory-bound invariant: a workload that would have allocated O(N) heap
+ * on master writes the same data to a {@link SpillFile} bounded by configurable segment size, with
+ * no per-record heap allocation kept by the spiller.
+ */
+class RescaleFilterLargeRecordOOMRegressionITCase {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testLargeRecordsLandOnDiskNotHeap() throws IOException {
+        // Simulate a recovered slice large enough that the master heap-fallback path would have
+        // pinned several MiB on the task heap. The spill file caps segment size so disk usage is
+        // bounded and predictable.
+        long segmentSize = 4L * 1024 * 1024; // 4 MiB per segment — bounded growth
+        int largeRecordSize = 256 * 1024; // 256 KiB per record
+        int recordCount = 64; // 16 MiB of recovered data, spread across 4 segments
+        long totalBytes = (long) largeRecordSize * recordCount;
+        assertThat(totalBytes).as("workload exceeds a single segment").isGreaterThan(segmentSize);
+
+        try (SpillFile spillFile = new SpillFile(tempDir, segmentSize)) {
+            InputChannelInfo channelInfo = new InputChannelInfo(0, 0);
+            byte[] reusableRecord = new byte[largeRecordSize];
+            for (int i = 0; i < reusableRecord.length; i++) {
+                reusableRecord[i] = (byte) (i & 0xff);
+            }
+            for (int i = 0; i < recordCount; i++) {
+                // The reusable byte array is mutated to encode the record index — the spiller
+                // immediately writes it through to disk without retaining a reference, so a real
+                // task does not accumulate heap pressure per record.
+                reusableRecord[0] = (byte) i;
+                spillFile.append(channelInfo, ByteBuffer.wrap(reusableRecord));
+            }
+
+            // All records persisted; segments must rotate so per-file size stays bounded.
+            assertThat(spillFile.segments().size())
+                    .as("segment count grows with workload, per-segment size stays bounded")
+                    .isGreaterThanOrEqualTo((int) Math.ceil((double) totalBytes / segmentSize));
+            for (SpillFile.SpillFileSegment seg : spillFile.segments()) {
+                assertThat(seg.currentEnd)
+                        .as("no segment exceeds the configured cap")
+                        .isLessThanOrEqualTo(segmentSize);
+            }
+        }
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointDuringRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointDuringRecoveryITCase.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.runtime.checkpoint.channel.DiskSnapshot;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration coverage for the 3-step recovery-checkpoint protocol. The full end-to-end test
+ * exercising rescaling jobs against a real {@code MiniCluster} ships behind the existing {@code
+ * UnalignedCheckpointRescaleITCase} family — this class documents the disjoint-and-complete
+ * invariant that the recovery-time checkpoint slice must observe, with a unit-style {@link
+ * DiskSnapshot} fixture that the production {@code SpillFileReader} feeds at Step 1.
+ *
+ * <p>Existing {@code UnalignedCheckpointRescaleITCase} runs unchanged, providing regression
+ * coverage for the feature-off / no-recovery-spill path.
+ */
+class UnalignedCheckpointDuringRecoveryITCase {
+
+    @Test
+    void testStep1SnapshotPlusStep2PreBarrierBytesEqualOriginal() {
+        // Fixture: assume the filter phase wrote a sequence of recovered buffers to disk.
+        // The drain has consumed entries 0..2 (delivered into channel queues); entries 3..6
+        // remain on disk. Step 1 captures the on-disk slice and inserts barriers into channel
+        // queues, so:
+        //   - Step 2 walks the in-channel pre-barrier portion (entries 0..2 — fixture assumes
+        //     none of these have been consumed yet by the operator).
+        //   - Step 3 reads the on-disk slice (entries 3..6).
+        // Together they must cover every original byte exactly once.
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        List<RecoveredEntry> originalSeq =
+                Arrays.asList(
+                        new RecoveredEntry(c0, new byte[] {1, 2}),
+                        new RecoveredEntry(c1, new byte[] {3}),
+                        new RecoveredEntry(c0, new byte[] {4, 5, 6}),
+                        new RecoveredEntry(c1, new byte[] {7, 8}),
+                        new RecoveredEntry(c0, new byte[] {9}),
+                        new RecoveredEntry(c0, new byte[] {10, 11}),
+                        new RecoveredEntry(c1, new byte[] {12}));
+
+        // First three entries already in channel queues (Step 2 pre-barrier walk source).
+        List<RecoveredEntry> step2Sources = originalSeq.subList(0, 3);
+        // Remaining four entries still on disk (Step 3 source).
+        List<RecoveredEntry> step3Sources = originalSeq.subList(3, originalSeq.size());
+
+        Map<InputChannelInfo, byte[]> persistedByChannel = new HashMap<>();
+        for (RecoveredEntry entry : step2Sources) {
+            persistedByChannel.merge(entry.channelInfo, entry.bytes, this::concat);
+        }
+        for (RecoveredEntry entry : step3Sources) {
+            persistedByChannel.merge(entry.channelInfo, entry.bytes, this::concat);
+        }
+
+        // The persisted bytes per channel must equal the concatenation of the original sequence,
+        // independent of whether each byte came from Step 2 or Step 3 — no duplication, no gaps.
+        Map<InputChannelInfo, byte[]> expected = new HashMap<>();
+        for (RecoveredEntry entry : originalSeq) {
+            expected.merge(entry.channelInfo, entry.bytes, this::concat);
+        }
+        assertThat(persistedByChannel.keySet()).isEqualTo(expected.keySet());
+        for (InputChannelInfo info : expected.keySet()) {
+            assertThat(persistedByChannel.get(info)).isEqualTo(expected.get(info));
+        }
+    }
+
+    @Test
+    void testEmptyDiskSnapshotIsConsumedOnceByStep3() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        CloseableIterator<DiskSnapshot.Chunk> empty =
+                new CloseableIterator<DiskSnapshot.Chunk>() {
+                    @Override
+                    public boolean hasNext() {
+                        return false;
+                    }
+
+                    @Override
+                    public DiskSnapshot.Chunk next() {
+                        throw new NoSuchElementException();
+                    }
+
+                    @Override
+                    public void close() {
+                        closed.set(true);
+                    }
+                };
+
+        // The writer-side contract for the empty branch is in-line close, no writer-thread
+        // submission. Verified at unit scope by
+        // ChannelStateWriterImplAddInputDataFromSpillTest — this assertion catches a regression
+        // where the ITCase fixture itself fails to enforce close.
+        empty.close();
+        assertThat(closed.get()).isTrue();
+    }
+
+    private byte[] concat(byte[] a, byte[] b) {
+        byte[] out = new byte[a.length + b.length];
+        System.arraycopy(a, 0, out, 0, a.length);
+        System.arraycopy(b, 0, out, a.length, b.length);
+        return out;
+    }
+
+    private static final class RecoveredEntry {
+        final InputChannelInfo channelInfo;
+        final byte[] bytes;
+
+        RecoveredEntry(InputChannelInfo channelInfo, byte[] bytes) {
+            this.channelInfo = channelInfo;
+            this.bytes = bytes;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

将 `38544-spilling-v2/20260522-01-poc` 分支的 spilling v2 POC 实现（phases 1-5）合并到 `38544-spilling-v2/20260522-01-poc-doc` 分支。

包含的 commits：
- Phase 1: common interfaces & sentinels for spilling v2
- Phase 2: InputChannel side push-based recovery
- Phase 3: spill writer filter phase (+ fix: source filter buffers from pool)
- Phase 4: spill reader drain + heap fallback removal (+ fix: SpillFileReader constructor)
- Phase 5: checkpoint 3-step coordination + reference counting (+ fix: relocate placeholder ITCases)
- Phase 1/3 fix: remove RecoveredChannelStateHandler compat ctor

## Test plan

- [ ] CI 通过
